### PR TITLE
Filter operators and pagination

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -55,6 +55,8 @@ jobs:
             pytest tests/test_model_deletions.py;
             pytest tests/test_models.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -114,6 +116,8 @@ jobs:
             pytest tests/test_model_deletions.py;
             pytest tests/test_models.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -166,6 +170,8 @@ jobs:
             pytest tests/test_model_deletions.py;
             pytest tests/test_models.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -56,6 +56,8 @@ jobs:
             pytest tests/test_models.py;
             pytest tests/test_model_advanced.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -109,6 +111,8 @@ jobs:
             pytest tests/test_models.py;
             pytest tests/test_model_advanced.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -173,6 +177,8 @@ jobs:
             pytest tests/test_models.py;
             pytest tests/test_model_advanced.py;
             pytest tests/test_query_caching.py;
+            pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;

--- a/docs/database-usage.md
+++ b/docs/database-usage.md
@@ -4,24 +4,24 @@ The Sqlite, Mysql and Postgres trio are supported for use with pydbantic via URL
 
 ### SqLite
 ```python
-    db = await Database.create(
-        'sqlite:///company.db',
-        tables=[Employee]
-    )
+db = await Database.create(
+    'sqlite:///company.db',
+    tables=[Employee]
+)
 ```
 
 ### Mysql
 ```python
-    db = await Database.create(
-        'mysql://codemation:abcd1234@127.0.0.1/company',
-        tables=[Employee]
-    )
+db = await Database.create(
+    'mysql://codemation:abcd1234@127.0.0.1/company',
+    tables=[Employee]
+)
 ```
 
 ### Postgres
 ```python
-    db = await Database.create(
-        'postgresql://codemation:abcd1234@localhost/database',
-        tables=[Employee]
-    )
+db = await Database.create(
+    'postgresql://codemation:abcd1234@localhost/database',
+    tables=[Employee]
+)
 ```

--- a/docs/model-usage.md
+++ b/docs/model-usage.md
@@ -43,40 +43,40 @@ class Employee(DataBaseModel):
 #### Create Model & Save Immediately in Database
 
 ```python
-    # create department 
-    hr_department = await Department.create(
-        id='d1234',
-        name='hr'
-        company='abc-company',
-        is_sensitive=True,
-    )
+# create department 
+hr_department = await Department.create(
+    id='d1234',
+    name='hr'
+    company='abc-company',
+    is_sensitive=True,
+)
 ```
 #### Create Model & Save to DB later
 
 ```python
-    # create department 
-    hr_department = Department(
-        id='d1234',
-        name='hr'
-        company='abc-company',
-        is_sensitive=True,
-    )
+# create department 
+hr_department = Department(
+    id='d1234',
+    name='hr'
+    company='abc-company',
+    is_sensitive=True,
+)
 
-    await hr_department.insert()
+await hr_department.insert()
 ```
 
 #### Create Model & Save / Update Later
 
 ```python
-    # create department 
-    hr_department = Department(
-        id='d1234',
-        name='hr'
-        company='abc-company',
-        is_sensitive=True,
-    )
+# create department 
+hr_department = Department(
+    id='d1234',
+    name='hr'
+    company='abc-company',
+    is_sensitive=True,
+)
 
-    await hr_department.save()
+await hr_department.save()
 
 ```
 
@@ -87,11 +87,37 @@ class Employee(DataBaseModel):
 #### Filtering
 In this example, `hr_manager` is a `DataBaseModel` named `Position` which has attributes indicating it's position in hr department. 
 ```python
-    # get all hr managers currently employed
-    managers = await Employee.filter(
-        position=hr_manager,
-        is_employed=True
-    )
+# get all hr managers currently employed
+managers = await Employee.filter(
+    position=hr_manager,
+    is_employed=True
+)
+```
+##### Filtering - Operators
+`DataBaseModel`s are equipped with operator methods allow a more complete filtering of desired objects:
+
+```python
+# greater than or equal
+big_salary_employee = await Employees.filter(
+    Employees.gte('salary', 50000)
+)
+
+# combined - operators
+mid_salary_employee = await Employees.filter(
+    Employees.gte('salary', 30000),
+    Employees.lte('salary', 40000)
+)
+
+low_and_high_salary = await Employees.filter(
+    Employees.lt('salary', 20000),
+    Employees.gt('salary', 40000)
+)
+
+# text searching
+employees_starting_with_jo = await EmployeeInfo.filter(
+    EmployeeInfo.contains('first_name', 'jo')
+)
+
 ```
 
 #### Get - Primary Key
@@ -101,35 +127,57 @@ Objects can be querrried by primary_key using .get() method on a `DataBaseModel`
 In this example, `Employee` objects are querried for an employee matching a specific 'id', 'id' is the `DataBaseModel` primary key, i.e the first entry in the model
 
 ```python
-    an_employee = await Employee.get(id='abcd1234')
+an_employee = await Employee.get(id='abcd1234')
 ```
 
 #### All Objects
 All objects for a given `DataBaseModel` can be querried by using the `.all()` method. 
 
 ```python
-    all_employees = await Employee.all()
+all_employees = await Employee.all()
 ```
+
+#### Pagination
+`DataBaseModel` query methods `.all()` and `.filter` can be provided with `limit=` and/or `offset=` to generate paginated results.
+
+```python
+
+first_100 = await Employees.all(limit=100, offset=0)
+
+second_100 = await Empoyees.all(limit=100, offset=100)
+
+```
+
+```
+# latest 25 employees that are still employed
+
+latest_employees = await Employees.filter(
+    is_employed=True,
+    limit=25,
+    offset=175
+)
+```
+
 
 ### Model Usage - Updating
 Updates to `DataBaseModel` objects must be done directly via an object instance, related `DataBaseModel` field objects must be updated by calling the related fields object's `.save()` or `.update()` method. 
 
 
 ```python
-    all_employees = await Employees.select('*')
-    
-    # update is_employed to False for all employees
+all_employees = await Employees.select('*')
 
-    for employee in all_employees:
-        employee.is_employed=False
-        await employee.update()
+# update is_employed to False for all employees
 
-    
-    # updating position name of each employee
-    for employee in all_employees:
-        position = employee.position
-        position.name = f"{position.name} - terminated"
-        await position.update()
+for employee in all_employees:
+    employee.is_employed=False
+    await employee.update()
+
+
+# updating position name of each employee
+for employee in all_employees:
+    position = employee.position
+    position.name = f"{position.name} - terminated"
+    await position.update()
 ```
 !!! TIP
     `.save()` can also be used, but first verified object existence before attempting save, while `.update()` does not verify before attempting to update. 
@@ -138,10 +186,10 @@ Updates to `DataBaseModel` objects must be done directly via an object instance,
 Much like updates, `DataBaseModel` objects can only be deleted by directly calling the `.delete()` method of an object instance. 
 
 ```python
-    all_employees = await Employees.select('*')
-    
-    # delete latest employee
-    await all_employees[-1].delete()
+all_employees = await Employees.select('*')
+
+# delete latest employee
+await all_employees[-1].delete()
 ```
 
 !!! WARNING

--- a/docs/redis-usage.md
+++ b/docs/redis-usage.md
@@ -2,12 +2,12 @@
 Redis can be enabled for use with Pydbantic by simply passing in a redis URL string into `Database.create()` such as `redis://localhost`
 
 ```python
-    database = await Database.create(
-            sqlite:///company.db,  
-            tables=[Employee],
-            cache_enabled=True,
-            redis_url='redis://localhost'
-        )
+database = await Database.create(
+        sqlite:///company.db,  
+        tables=[Employee],
+        cache_enabled=True,
+        redis_url='redis://localhost'
+    )
 ```
 
 ### Considerations

--- a/docs/tutorials.md
+++ b/docs/tutorials.md
@@ -1,0 +1,3 @@
+## Tutorials
+
+- [Introduction to Pydbantic](https://itnext.io/an-introduction-to-pydbantic-a-single-model-solution-to-data-verification-storage-254cfe9e757f)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Pydbantic: index.md
   - Setup: setup.md
   - Quick Start: quick-start.md
+  - Tutorials: tutorials.md
   - Model Usage: model-usage.md
   - Database Usage: database-usage.md
   - Redis: redis-usage.md

--- a/pydbantic/cache.py
+++ b/pydbantic/cache.py
@@ -9,10 +9,10 @@ import aioredis
 
 class Redis:
     def __init__(self,
-        url: str = "redis://localhost",
+        redis_url: str = "redis://localhost",
         log: logging.Logger = logging.getLogger(__name__)
     ):
-        self.redis = aioredis.from_url(url)
+        self.redis = aioredis.from_url(redis_url)
         self.log = log
 
     async def get(self, key):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -70,16 +70,16 @@ async def empty_database_and_model_with_cache(database_with_cache):
 async def loaded_database_and_model(database_with_cache):
     db, Employee = database_with_cache
     async with db:
-        for _ in range(200):
+        for i in range(200):
             employee = Employee(**json.loads(
         f"""
   {{
     "id": "abcd{time.time()}",
     "employee_info": {{
-      "ssn": "1234",
+      "ssn": "{i}",
       "first_name": "joe",
       "last_name": "last",
-      "address": "123 lane",
+      "address": "{i} lane",
       "address2": null,
       "city": null,
       "zip": null

--- a/tests/test_model_filtering_operators.py
+++ b/tests/test_model_filtering_operators.py
@@ -1,0 +1,42 @@
+import pytest
+from tests.models import EmployeeInfo
+
+@pytest.mark.asyncio
+async def test_model_filtering_operators(loaded_database_and_model):
+    db, Employees = loaded_database_and_model
+
+    all_employees = await Employees.all()
+
+    print(f"Number of Employees is ", len(all_employees))
+
+    assert len(all_employees) == 200
+
+    for i in range(1, 6):
+        all_employees[i].salary = i * 10000
+        await all_employees[i].save()
+
+    big_salary_employee = await Employees.filter(
+        Employees.gte('salary', 50000)
+    )
+    assert len(big_salary_employee) == 1
+
+
+    mid_salary_employee = await Employees.filter(
+        Employees.gte('salary', 30000),
+        Employees.lte('salary', 40000)
+    )
+    assert len(mid_salary_employee) == 2
+
+    low_and_high_salary = await Employees.filter(
+        Employees.lt('salary', 20000),
+        Employees.gt('salary', 40000)
+    )
+
+    assert len(mid_salary_employee) == 2
+
+
+    employees_starting_with_jo = await EmployeeInfo.filter(
+        EmployeeInfo.contains('first_name', 'jo')
+    )
+    assert len(employees_starting_with_jo) == 200
+

--- a/tests/test_model_limit_offset.py
+++ b/tests/test_model_limit_offset.py
@@ -1,0 +1,22 @@
+import pytest
+
+@pytest.mark.asyncio
+async def test_model_limits_and_offsets(loaded_database_and_model):
+    db, Employees = loaded_database_and_model
+
+    all_employees = await Employees.all()
+
+    print(f"Number of Employees is ", len(all_employees))
+
+    assert len(all_employees) == 200
+
+    limited = await Employees.all(limit=100, offset=0)
+    assert len(limited) == 100
+    
+    limited_offset = await Employees.all(limit=25, offset=175)
+    #breakpoint()
+    assert len(limited_offset) == 25
+
+    limited_offset_filtered = await Employees.filter(is_employed=True, limit=25, offset=175)
+    #breakpoint()
+    assert len(limited_offset) == 25


### PR DESCRIPTION
## Description
This PR adds support for filter operators and pagination. 

### Whats Included
- Added gt, gte, lt, lte, and contains  class methods to be used inside of .filter() as operators to perform <,>, <=, >=, and string search during filter. Added limit / offset arguments to .all() and .filter() to enable paginated results of all or filtered sets of objects

```python
# greater than or equal
big_salary_employee = await Employees.filter(
    Employees.gte('salary', 50000)
)

# combined - operators
mid_salary_employee = await Employees.filter(
    Employees.gte('salary', 30000),
    Employees.lte('salary', 40000)
)

low_and_high_salary = await Employees.filter(
    Employees.lt('salary', 20000),
    Employees.gt('salary', 40000)
)

# text searching
employees_starting_with_jo = await EmployeeInfo.filter(
    EmployeeInfo.contains('first_name', 'jo')
)

```

`DataBaseModel` query methods `.all()` and `.filter` can be provided with `limit=` and/or `offset=` to generate paginated results.

```python

first_100 = await Employees.all(limit=100, offset=0)

second_100 = await Empoyees.all(limit=100, offset=100)

```

```
# latest 25 employees that are still employed

latest_employees = await Employees.filter(
    is_employed=True,
    limit=25,
    offset=175
)
```

## Fixes 
-  Modified init redis_url argument to match docs & database cache_enabled arguments

### Tests 
- Created tests for new operators and pagination, improved variations of EmployeeInfo test data, used in operator tests, added tests to Github CICD

### Documentation
- Updated docs with new operator & pagination examples, improved formatting used on other example pages