### PR TITLE
Feature -  DataBaseModel Count and filter count

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,6 +57,7 @@ jobs:
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
             pytest tests/test_model_limit_offset.py;
+            pytest tests/test_model_counting.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -118,6 +119,7 @@ jobs:
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
             pytest tests/test_model_limit_offset.py;
+            pytest tests/test_model_counting.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -172,6 +174,7 @@ jobs:
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
             pytest tests/test_model_limit_offset.py;
+            pytest tests/test_model_counting.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -58,6 +58,7 @@ jobs:
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
             pytest tests/test_model_limit_offset.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
             pytest tests/test_integration_fastapi.py;
@@ -112,6 +113,7 @@ jobs:
             pytest tests/test_model_advanced.py;
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;
@@ -178,6 +180,7 @@ jobs:
             pytest tests/test_model_advanced.py;
             pytest tests/test_query_caching.py;
             pytest tests/test_model_filtering_operators.py;
+            pytest tests/test_model_limit_offset.py;
             pytest tests/test_model_limit_offset.py;
             pytest tests/test_querying.py;
             pytest tests/test_query_no_caching.py;

--- a/docs/model-usage.md
+++ b/docs/model-usage.md
@@ -169,7 +169,17 @@ latest_employees = await Employees.filter(
     offset=175
 )
 ```
+#### Counting
+`DataBaseModel` objects can be counted by calling the `.count()` method. Filtered `DataBaseModel` objects can use `.filter(.., count_rows=True)` to return a total count of objects matching a given filter.
 
+```python
+employee_count = await Employees.count()
+
+employed_count = await Employees.filter(
+      is_employed=True,
+      count_rows=True
+)
+```
 
 ### Model Usage - Updating
 Updates to `DataBaseModel` objects must be done directly via an object instance, related `DataBaseModel` field objects must be updated by calling the related fields object's `.save()` or `.update()` method. 

--- a/tests/test_model_counting.py
+++ b/tests/test_model_counting.py
@@ -1,0 +1,31 @@
+import pytest
+from tests.models import EmployeeInfo
+
+@pytest.mark.asyncio
+async def test_model_counting(loaded_database_and_model):
+    db, Employees = loaded_database_and_model
+
+    all_employees = await Employees.all()
+    employee_count = await Employees.count()
+
+    print(f"Number of Employees is ", employee_count)
+
+    assert employee_count == len(all_employees)
+
+    employed = await Employees.filter(
+        is_employed=True
+    )
+
+    employed_count = await Employees.filter(
+        is_employed=True,
+        count_rows=True,
+    )
+
+    assert len(employed) == employed_count
+
+    un_employed = await Employees.filter(
+        is_employed=False,
+        count_rows=True
+    )
+    assert un_employed == 0
+    


### PR DESCRIPTION
## Description
This PR implements `DataBaseModel` `.count()` method to more efficiently determine a total number of objects, and integrated the same logic into `.filter(count_rows=True)` which causes filter to return an integer count objects matching a given set of filters.

```python
employee_count = await Employees.count()

employed_count = await Employees.filter(
      is_employed=True,
      count_rows=True
)
```