### PR TITLE
Improved model filtering conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,8 +133,12 @@ Note: At this point only the models have been created, but nothing is saved in t
 ```python
     # get all hr managers currently employed
     managers = await Employee.filter(
-        position=hr_manager,
-        is_employed=True
+        Employee.position==hr_manager, # conditional
+        is_employed=True               # key-word argument
+    )
+
+    first_100_employees = await Employee.all(
+        limit=100
     )
 
 ```
@@ -263,8 +267,5 @@ class Coordinate(DataBaseModel):
 class Journey(DataBaseModel):
     trip_id: str = PrimaryKey(default=get_uuid4)
     waypoints: List[Optional[Coordinate]]
-
-
-
 
 ```

--- a/docs/model-usage.md
+++ b/docs/model-usage.md
@@ -94,7 +94,35 @@ managers = await Employee.filter(
 )
 ```
 ##### Filtering - Operators
-`DataBaseModel`s are equipped with operator methods allow a more complete filtering of desired objects:
+`DataBaseModel`s can be filtered using `>`, `>=`, `<=`, `<`, `==`, and a `.matches([value1, value2, value3])` 
+
+```python
+# conditionals
+mid_salary_employees = await Employees.filter(
+    Employees.salary >= 30000,
+    Employees.salary <= 40000
+)
+
+mid_salary_employees = await Employees.filter(
+    Employees.salary.matches([30000, 40000])
+)
+
+mid_salary_employees = await Employees.filter(
+    Employees.salary == 30000,
+)
+
+# combining conditionals with keyword args
+mid_salary_employees = await Employees.filter(
+    Employees.OR(
+        Employees.salary >= 30000,
+        Employees.salary.matches([20000, 40000])
+    ),
+    is_employed = True
+)
+
+```
+
+`DataBaseModel`s are also equipped with operator methods allowing for additional filtering of desired objects
 
 ```python
 # greater than or equal
@@ -186,7 +214,7 @@ Updates to `DataBaseModel` objects must be done directly via an object instance,
 
 
 ```python
-all_employees = await Employees.select('*')
+all_employees = await Employees.all()
 
 # update is_employed to False for all employees
 
@@ -208,7 +236,7 @@ for employee in all_employees:
 Much like updates, `DataBaseModel` objects can only be deleted by directly calling the `.delete()` method of an object instance. 
 
 ```python
-all_employees = await Employees.select('*')
+all_employees = await Employees.all()
 
 # delete latest employee
 await all_employees[-1].delete()

--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -416,8 +416,9 @@ class Database():
                 
             # update TableMeta with new Model
             await self.update_table_meta(table, existing=True)
-
+            
             table.__metadata__.tables[table.__name__]['table'] = new_table
+            table.generate_model_attributes()
 
         if reservation == database_init.reservation:
             self.log.warning(f"database init - ready")

--- a/tests/test_model_filtering_operators.py
+++ b/tests/test_model_filtering_operators.py
@@ -58,3 +58,45 @@ async def test_model_filtering_operators(loaded_database_and_model):
         if i == 0:
             continue
         assert employees_with_salary[i].salary < employees_with_salary[i-1].salary
+
+    mid_salary_employees = await Employees.filter(
+
+        Employees.gte('salary', 30000),
+        Employees.lte('salary', 40000)
+    )
+    assert len(mid_salary_employee) == 2
+
+    mid_salary_employees = await Employees.filter(
+        Employees.salary >= 30000,
+        Employees.salary <= 40000
+    )
+
+    assert len(mid_salary_employee) == 2
+
+    mid_salary_employees = await Employees.filter(
+        Employees.salary.matches([30000, 40000])
+    )
+    
+    assert len(mid_salary_employee) == 2
+
+    mid_salary_employees = await Employees.filter(
+        Employees.salary == 30000,
+    )
+    assert len(mid_salary_employee) == 2
+
+    init_employees = await Employees.filter(
+        Employees.salary >= 30000
+    )
+    second_employees = await Employees.filter(
+        Employees.salary.matches([20000, 40000])
+    )
+
+    mid_salary_employees = await Employees.filter(
+        Employees.OR(
+            Employees.salary >= 30000,
+            Employees.salary.matches([20000, 40000])
+        ),
+        Employees.is_employed == True
+    )
+    
+    assert len(mid_salary_employees) == 4

--- a/tests/test_querying.py
+++ b/tests/test_querying.py
@@ -20,6 +20,10 @@ async def test_querying(loaded_database_and_model_with_cache):
 
     assert emp_with_salary[0].salary == 40000
 
+    emp_with_salary = await Employee.filter(Employee.salary==40000)
+
+    assert emp_with_salary[0].salary == 40000
+
     manager_position = emp_with_salary[0].position
 
     # filter on manager positions
@@ -31,6 +35,14 @@ async def test_querying(loaded_database_and_model_with_cache):
 
     assert len(managers) ==1
 
+    # filter on manager positions
+    managers = await Employee.filter(
+        Employee.position==manager_position, 
+        Employee.salary==40000, 
+        Employee.employee_info==emp_with_salary[0].employee_info
+    )
+    assert len(managers) ==1
+
     assert managers[0].salary == 40000
 
     assert managers[0].employee_info.ssn == emp_with_salary[0].employee_info.ssn
@@ -38,3 +50,12 @@ async def test_querying(loaded_database_and_model_with_cache):
     manager = await Employee.get(id=managers[0].id)
 
     assert manager.id == managers[0].id
+
+    manager = await Employee.get(Employee.id==managers[0].id)
+
+    assert manager.id == managers[0].id
+
+    ranged_salary = await Employee.filter(
+        Employee.salary.matches([40000, 10000, 30000])
+    )
+    assert len(ranged_salary) ==1


### PR DESCRIPTION
## Description
In this PR,  `DataBaseModelCondition` and `DataBaseModelAttribute` is created  to improved annotation with conditions and to store / store values associated with query conditions needed for query caching.   `DataBaseModelAttribute` is used to easily reference sqlalchemy models associated with model attributes, also provide an interface for storing values associated with sqlalchemy conditions, and enabling attribute based Conditionals in filters. At startup, or post migration, DataBaseModels now have attributes with names matching associated fields used for filter condition. Added new   method, allowing for grouping of conditionals which do not ALL need to be True.  data attributes now have a .matches() method which allows for IN [value1, value2, value3] querries



### Examples

```python

    mid_salary_employees = await Employees.filter(
        Employees.salary >= 30000,
        Employees.salary <= 40000
    )

    second_employees = await Employees.filter(
        Employees.salary.matches([20000, 40000])
    )


    mid_salary_employees = await Employees.filter(
        Employees.OR(
            Employees.salary >= 30000,
            Employees.salary.matches([20000, 40000])
        ),
        Employees.is_employed == True
    )
```


