### PR TITLE
Dynamic model relationships

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -171,6 +171,7 @@ jobs:
       - name: Run Tests - Sqlite
         run: |
           for env in sqlite; do
+            export ENV=$env; 
             pytest tests/test_database.py -s -x;
             pytest tests/test_integration_fastapi.py -s -x;
             pytest tests/test_model_1_to_1.py -s -x;

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -65,7 +65,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done
@@ -130,7 +130,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done
@@ -187,7 +187,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,22 +49,25 @@ jobs:
         run: |
           for env in postgres; do
             export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_counting.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done
   test-mysql:
     # Containers must run in Linux based operating systems
@@ -111,22 +114,25 @@ jobs:
         run: |
           for env in mysql; do
             export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_counting.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done
 
   # Label of the container job
@@ -165,21 +171,23 @@ jobs:
       - name: Run Tests - Sqlite
         run: |
           for env in sqlite; do
-            export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_counting.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -64,7 +64,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done
@@ -122,7 +122,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done
@@ -191,7 +191,7 @@ jobs:
             pytest tests/test_query_caching.py -s -x;
             pytest tests/test_querying.py -s -x;
             pytest tests/test_query_no_caching.py -s -x;
-            for mig_test in {0..7}; do 
+            for mig_test in {0..9}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
           done

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -48,24 +48,25 @@ jobs:
       - name: Run Tests - mysql
         run: |
           for env in mysql; do
-            export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_model_advanced.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done
 
   # Label of the container job
@@ -105,23 +106,25 @@ jobs:
         run: |
           for env in sqlite; do
             export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_model_advanced.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done
   test-postgres:
     needs: test-mysql
@@ -172,21 +175,23 @@ jobs:
         run: |
           for env in postgres; do
             export ENV=$env; 
-            pytest tests/test_database.py;
-            pytest tests/test_model_insertions.py;
-            pytest tests/test_model_updates.py;
-            pytest tests/test_model_deletions.py;
-            pytest tests/test_models.py;
-            pytest tests/test_model_advanced.py;
-            pytest tests/test_query_caching.py;
-            pytest tests/test_model_filtering_operators.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_model_limit_offset.py;
-            pytest tests/test_querying.py;
-            pytest tests/test_query_no_caching.py;
-            pytest tests/test_integration_fastapi.py;
+            pytest tests/test_database.py -s -x;
+            pytest tests/test_integration_fastapi.py -s -x;
+            pytest tests/test_model_1_to_1.py -s -x;
+            pytest tests/test_model_advanced.py -s -x;
+            pytest tests/test_model_connections.py -s -x;
+            pytest tests/test_model_counting.py -s -x;
+            pytest tests/test_model_deletions.py -s -x;
+            pytest tests/test_model_filtering_operators.py -s -x;
+            pytest tests/test_model_insertions.py -s -x;
+            pytest tests/test_model_limit_offset.py -s -x;
+            pytest tests/test_model_many_to_many.py -s -x;
+            pytest tests/test_models.py -s -x;
+            pytest tests/test_model_updates.py -s -x;
+            pytest tests/test_query_caching.py -s -x;
+            pytest tests/test_querying.py -s -x;
+            pytest tests/test_query_no_caching.py -s -x;
             for mig_test in {0..7}; do 
               pytest tests/migrations/test_model_migration_$mig_test.py;
             done
-            pytest tests/test_model_connections.py
           done

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -48,6 +48,7 @@ jobs:
       - name: Run Tests - mysql
         run: |
           for env in mysql; do
+            export ENV=$env; 
             pytest tests/test_database.py -s -x;
             pytest tests/test_integration_fastapi.py -s -x;
             pytest tests/test_model_1_to_1.py -s -x;

--- a/pydbantic/cache.py
+++ b/pydbantic/cache.py
@@ -22,12 +22,15 @@ class Redis:
         return None
         
     async def set(self, cached_key, row_and_flag: tuple):
-        row, flag = row_and_flag
+        row, flags = row_and_flag
         await asyncio.gather(
             self.redis.set(
-                cached_key, dumps(([dict(r) for r in row], flag))
+                cached_key, dumps(([dict(r) for r in row], flags))
             ),
-            self.redis.rpush(f'f_{flag}', cached_key)
+            *[
+                self.redis.rpush(f'f_{flag}', cached_key)
+                for flag in flags
+            ],
         )
 
     async def invalidate(self, flag: str):

--- a/pydbantic/cache.py
+++ b/pydbantic/cache.py
@@ -40,7 +40,7 @@ class Redis:
             return
         
         await self.redis.delete(f'f_{flag}', *cache_keys)
-        self.log.warning(f"cache flag {flag} invalidated {len(cache_keys)} items")
+        self.log.debug(f"cache flag {flag} invalidated {len(cache_keys)} items")
 
 
 

--- a/pydbantic/core.py
+++ b/pydbantic/core.py
@@ -39,9 +39,6 @@ class RelationshipRef(BaseModel):
     def __call__(self) -> Coroutine:
         return self._method_()
 
-    # def _get_value(self):
-    #     return self._default_
-
     def dict(self, *args, **kwargs):
         return {f"{self.primary_key}": self.value}
         
@@ -804,7 +801,7 @@ class DataBaseModel(BaseModel):
 
         database = cls.__metadata__.database
 
-        results = await database.fetch(sel, cls.__name__, values)
+        results = await database.fetch(sel, {cls.__name__}, values)
 
         return bool(results)
 
@@ -927,7 +924,7 @@ class DataBaseModel(BaseModel):
         if order_by is not None:
             sel = sel.order_by(order_by)
 
-        results = await database.fetch(sel.statement, cls.__name__, values)
+        results = await database.fetch(sel.statement, models_selected, values)
         
         # build results_map
         results_map = {}
@@ -1107,7 +1104,7 @@ class DataBaseModel(BaseModel):
         database = cls.__metadata__.database
         session = Session(database.engine)
         sel = session.query(func.count()).select_from(table)
-        results = await database.fetch(sel.statement, cls.__name__)
+        results = await database.fetch(sel.statement, {cls.__name__})
         return results[0][0] if results else 0
 
     @classmethod
@@ -1157,7 +1154,7 @@ class DataBaseModel(BaseModel):
         sel, values = cls.check_limit_offset(sel.statement, values, limit, offset)
         
         if count_rows:
-            row_count = await database.fetch(sel.with_only_columns(func.count()), cls.__name__)
+            row_count = await database.fetch(sel.with_only_columns(func.count()), models_selected)
             if row_count:
                 if isinstance(row_count[0], dict):
                     return [v for _, v in row_count[0].items()][0]
@@ -1167,7 +1164,7 @@ class DataBaseModel(BaseModel):
         if not order_by is None:
             sel = sel.order_by(order_by)
 
-        results = await database.fetch(sel, cls.__name__, tuple(values))
+        results = await database.fetch(sel, models_selected, tuple(values))
 
         results_map = {}
         last_ind = -1

--- a/pydbantic/core.py
+++ b/pydbantic/core.py
@@ -1,12 +1,45 @@
-from pydantic import BaseModel, Field
+import asyncio
+from sqlalchemy.sql.elements import UnaryExpression
+from sqlalchemy.sql.expression import delete
+from sqlalchemy.util.langhelpers import NoneType
+from pydantic import BaseModel, Field, ValidationError
 import typing
-from typing import Iterable, Optional, Union, List, Any
+from typing import Awaitable, Callable, Coroutine, Optional, TypeVar, Union, List, Any, Tuple, ForwardRef
 import sqlalchemy
-from sqlalchemy import select, func, or_
+from sqlalchemy import select, func, or_, and_
+from sqlalchemy.orm import relationship, Session, Query
 from pickle import dumps, loads
 
 class _Generic(BaseModel):
     pass
+
+class RelationshipRef(BaseModel):
+    primary_key: str
+    value: Any
+    method: Callable 
+    def __init__(self, model, primary_key, value, default=None):
+        super().__init__(
+            primary_key=primary_key, 
+            value=value,
+            method=get_model_getter(model, primary_key, value)
+        )
+        self.Config.__model__ = model
+        self.Config.primary_key = primary_key
+        self.Config.value = value
+        self.Config.default = default
+
+    def __repr__(self):
+        return f"{self.value}"
+
+    def __call__(self):
+        return self.method()
+
+    def dict(self, *args, **kwargs):
+        #super().dict(*args, **kwargs)
+        return repr(self)
+
+def get_model_getter(model, primary_key, primary_key_value):
+    return lambda : model.get(**{primary_key: primary_key_value})
 
 def resolve_missing_attribute(missing_error: str):
     try:
@@ -17,12 +50,17 @@ def resolve_missing_attribute(missing_error: str):
         missing_mod = ''.join(
             missing_error.split("Can't get attribute")[1].split('on <module')
         ).split('from')[0].split(' ')[3][1:-1]
-
         mod = __import__(missing_mod)
         setattr(mod, missing_attr, _Generic)
     except Exception:
         pass
 
+def deserialize(data):
+    try:
+        return loads(data)
+    except AttributeError as e:
+        resolve_missing_attribute(repr(e))
+        return loads(data)
 
 class BaseMeta:
     translations: dict = {
@@ -45,6 +83,7 @@ def Default(default=...):
     if isinstance(default, type(lambda x: x)):
         return Field(default_factory=default)
     return Field(default=default)
+
 class DataBaseModelCondition:
     def __init__(
         self, 
@@ -66,17 +105,23 @@ class DataBaseModelAttribute:
         name: str,
         column: sqlalchemy.sql.schema.Column,
         table,
-        serialized: bool = False
+        serialized: bool = False,
+        is_array: bool = False,
+        foreign_model = None
     ):
         self.name = name
         self.column = column
         self.table = table
         self.serialized = serialized
+        self.is_array = is_array
+
+        self.foreign_model = foreign_model
+
     def process_value(self, value):
-        if self.name in self.table['foreign_keys']:
-            foreign_table_name = value.__class__.__name__
-            primary_key = value.__class__.__metadata__.tables[foreign_table_name]['primary_key']
+        if value.__class__ is self.table['model']:
+            primary_key = self.table['model'].__metadata__.tables[self.foreign_model]['primary_key']
             return getattr(value, primary_key)
+
         if self.serialized:
             return dumps(value)
 
@@ -129,25 +174,37 @@ class DataBaseModelAttribute:
             self.column.in_(choices),
             tuple(choices)
         )
+    def not_matches(self, choices: List[Any]) -> DataBaseModelCondition:
+        choices = [self.process_value(value) for value in choices]
+        return DataBaseModelCondition(
+            f"{self.name} not in {choices}",
+            self.column.not_in(choices),
+            tuple(choices)
+        )
+
+TDataBaseModel = TypeVar('DataBaseModel')
 
 class DataBaseModel(BaseModel):
     __metadata__: BaseMeta = BaseMeta()
-
+    
     @classmethod
     def check_if_subtype(cls, field):
 
         database_model = None
+
         if isinstance(field['type'], typing._GenericAlias):
             for sub in field['type'].__args__:
-                if issubclass(sub, DataBaseModel):
+                
+                if isinstance(sub, ForwardRef):
+                    database_model = sub.__forward_value__
+        
+                elif issubclass(sub, DataBaseModel):
                     if database_model:
                         raise Exception(f"Cannot Specify two DataBaseModels in Union[] for {field['name']}")
                     database_model = sub
         elif issubclass(field['type'], DataBaseModel):
             return field['type']
         return database_model
-            
-        
 
     @classmethod
     async def refresh_models(cls):
@@ -163,57 +220,137 @@ class DataBaseModel(BaseModel):
 
     @classmethod
     def setup(cls, database):
+        cls.update_backward_refs()
         
         if not hasattr(cls.__metadata__, 'metadata'):
             cls.init_set_metadata(database.metadata)
             cls.init_set_database(database)
         if cls.__name__ not in cls.__metadata__.tables:
             cls.generate_sqlalchemy_table()
-        
+
     @classmethod
-    def init_set_metadata(cls, metadata):
+    def init_set_metadata(cls, metadata) -> NoneType:
         """
         Applies an instantiated sqlalchemy.MetaData() instance to __metadata__.metadata
         """
         cls.__metadata__.metadata = metadata
     
     @classmethod
-    def init_set_database(cls, database):
+    def init_set_database(cls, database) -> NoneType:
         """
         Applies an instantiated easydb.Database() instance to __metadata__.database
         """
         cls.__metadata__.database = database
 
     @classmethod
-    def generate_sqlalchemy_table(cls):
+    def generate_sqlalchemy_table(cls) -> NoneType:
         if not hasattr(cls.__metadata__, 'metadata'):
             raise Exception(f"No connected sqlalchemy.MetaData() instance yet, first run {cls}.init_set_metadata()")
         name = cls.__name__
 
+        columns, link_tables = cls.convert_fields_to_columns()
+
+
+        database = cls.__metadata__.database
         cls.__metadata__.tables[name]['table'] = sqlalchemy.Table(
             name,
             cls.__metadata__.metadata,
-            *cls.convert_fields_to_columns()
+            *columns
         )
-        cls.generate_model_attributes()
+
+        for data_base_model, field_name in link_tables:
+            cls.generate_relationship_table(data_base_model, field_name)
+        
+
+        for rel, table in cls.__metadata__.tables[cls.__name__]['relationships'].items():
+            setattr(
+                cls.__metadata__.tables[name]['table'],
+                table[1],
+                relationship(
+                    rel,
+                    secondary=table[0],
+                    backref=table[2]
+                )
+            )
+
+    @classmethod
+    def generate_relationship_table(cls, related_model: TDataBaseModel, field_ref: str) -> NoneType:
+        """
+        creates a 2 column table that enables a link between
+        cls primary_key & related_model primary key 
+        """
+        
+        if related_model.__name__ in cls.__metadata__.tables[cls.__name__]['relationships']:
+            return
+        
+        related_model_ref = None
+        for f_name, field in related_model.__fields__.items():
+            data_base_model = related_model.check_if_subtype({'name': f_name, 'type': field.type_})
+            if data_base_model is cls:
+                related_model_ref = f_name
+
+
+        relationship_table = sqlalchemy.Table(
+            f"{cls.__name__}_to_{related_model.__name__}",
+            cls.__metadata__.metadata,
+            sqlalchemy.Column(
+                f"{cls.__name__}_{cls.__metadata__.tables[cls.__name__]['primary_key']}",
+                sqlalchemy.ForeignKey(
+                    f"{cls.__name__}.{cls.__metadata__.tables[cls.__name__]['primary_key']}",
+                    ondelete="CASCADE"
+                ),
+                primary_key=True
+            ),
+            sqlalchemy.Column(
+                f"{related_model.__name__}_{cls.__metadata__.tables[related_model.__name__]['primary_key']}",
+                sqlalchemy.ForeignKey(
+                    f"{related_model.__name__}.{cls.__metadata__.tables[related_model.__name__]['primary_key']}",
+                    ondelete="CASCADE"
+                ),
+                primary_key=True
+            )
+        )
+        
+        cls.__metadata__.tables[cls.__name__]['relationships'][related_model.__name__] = relationship_table, field_ref, related_model_ref
+        cls.__metadata__.tables[related_model.__name__]['relationships'][cls.__name__] = relationship_table, related_model_ref, field_ref
+
     @classmethod 
-    def generate_model_attributes(cls):
+    def generate_model_attributes(cls) -> NoneType:
         name = cls.__name__
         for c, column in cls.__metadata__.tables[name]['column_map'].items():
-            sql_c = c
+
+            foreign_model = None
             if c in cls.__metadata__.tables[name]['foreign_keys']:
-                sql_c = cls.__metadata__.tables[name]['foreign_keys'][c]
+                foreign_model = cls.__metadata__.tables[name]['foreign_keys'][c]
+                table = cls.__metadata__.tables[foreign_model.__name__]
+                foreign_pk = table['primary_key']
+                
+                table_column = table['table'].c[foreign_pk]
+            else:
+                table =  cls.__metadata__.tables[name]
+                table_column = table['table'].c[c]
+
             setattr(
                 cls, 
                 c, 
                 DataBaseModelAttribute(
                     c,
-                    cls.__metadata__.tables[name]['table'].c[sql_c],
-                    cls.__metadata__.tables[name],
-                    column[2]
+                    table_column,
+                    table,
+                    column[2],
+                    column[3],
+                    foreign_model=foreign_model.__name__ if foreign_model else None
                 )
             )
-
+    @classmethod
+    def update_backward_refs(cls):
+        """
+        force update forward refs of all backward referncing DataBaseModels
+        """
+        for _, model_field in cls.__fields__.items():
+            data_base_model = cls.check_if_subtype({'type': model_field.type_})
+            if data_base_model:
+                data_base_model.update_forward_refs()
         
     @classmethod
     def convert_fields_to_columns(
@@ -222,9 +359,11 @@ class DataBaseModel(BaseModel):
         include: list = None,
         alias: dict = None,
         update: bool = False
-    ):
+    ) -> Tuple[List[sqlalchemy.Column], List[Awaitable]]:
         """
-        primary key is assumed to be first field, #TODO - add override later
+        converts model fields to sqlalchemy columns, saturates
+        model.__metadata__  with model properties and relationship reference,
+        triggers foreign
         """
         if not alias:
             alias = {}
@@ -234,14 +373,28 @@ class DataBaseModel(BaseModel):
         primary_key = None
         array_fields = set()
 
-        for property, config in cls.schema()['properties'].items():
+        field_properties = {}
+
+        try:
+            model_schema = cls.schema()
+        except TypeError:
+            raise Exception(f"{cls.__name__} was referenced by DataBaseModel(s) not added in Database setup tables=[..,]")
+
+        if 'title' in model_schema and model_schema['title'] == cls.__name__:
+            field_properties = model_schema['properties']
+        elif 'definitions' in model_schema and cls.__name__ in model_schema['definitions']:
+            field_properties = model_schema['definitions'][cls.__name__]['properties']
+        else:
+            field_properties = model_schema['properties']
+
+        for field_property, config in field_properties.items():
             
             if 'primary_key' in config:
                 if primary_key:
                     raise Exception(f"Duplicate Primary Key Specified for {cls.__name__}")
-                primary_key = property
-            if 'type' in config and config['type'] == 'array':
-                array_fields.add(property)
+                primary_key = field_property
+            if 'type' in config and config['type'] == 'array' and not primary_key == field_property:
+                array_fields.add(field_property)
 
         if not model_fields:
             model_fields_list = [
@@ -263,45 +416,42 @@ class DataBaseModel(BaseModel):
                 'primary_key': primary_key,
                 'column_map': {},
                 'foreign_keys': {},
+                'relationships': {} if name not in cls.__metadata__.tables else cls.__metadata__.tables[name]['relationships']
             }
 
         columns = []
+        link_tables = []
         for i, field in enumerate(model_fields):
+            
             data_base_model = cls.check_if_subtype(field)
             if data_base_model:
                 # ensure DataBaseModel also exists in Database, even if not already
                 # explicity added
+                data_base_model.update_forward_refs()
                 cls.__metadata__.database.add_table(data_base_model)
-
+                
                 # create a string or foreign table column to be used to reference 
                 # other table
+                if not update:
+                    link_tables.append((data_base_model, field['name']))
+
                 foreign_table_name = data_base_model.__name__
                 foreign_primary_key_name = data_base_model.__metadata__.tables[foreign_table_name]['primary_key']
                 foreign_key_type = data_base_model.__metadata__.tables[foreign_table_name]['column_map'][foreign_primary_key_name][1]
 
-                serialize = field['name'] in array_fields
+                serialize = False
 
                 cls.__metadata__.tables[name]['column_map'][field['name']] = (
                     cls.__metadata__.database.get_translated_column_type(foreign_key_type if not serialize else list)[0],
                     data_base_model,
-                    serialize
+                    serialize,
+                    field['name'] in array_fields
                 )
 
                 # store field name in map to quickly determine attribute is tied to 
                 # foreign table
-                cls.__metadata__.tables[name]['foreign_keys'][field['name']] =  (
-                    f'fk_{foreign_table_name}_{foreign_primary_key_name}'.lower()
-                )
-                foreign_type_config = cls.__metadata__.tables[name]['column_map'][field['name']][0]
-                columns.append(
-                    sqlalchemy.Column(
-                        cls.__metadata__.tables[name]['foreign_keys'][field['name']],
-                        foreign_type_config['column_type'](
-                            *foreign_type_config['args'],
-                            **foreign_type_config['kwargs']
-                        )
-                    )
-                )
+                cls.__metadata__.tables[name]['foreign_keys'][field['name']] = data_base_model
+
                 continue
 
             # get sqlalchemy column type based on field type & if primary_key
@@ -313,8 +463,10 @@ class DataBaseModel(BaseModel):
             cls.__metadata__.tables[name]['column_map'][field['name']] = (
                 sqlalchemy_model,
                 field['type'],
-                serialize
+                serialize,
+                False, #field['name'] in array_fields
             )
+            cls.__metadata__.tables[name]['model'] = cls
 
             column_type_config = cls.__metadata__.tables[name]['column_map'][field['name']][0]
             columns.append(
@@ -328,106 +480,204 @@ class DataBaseModel(BaseModel):
                 )
             )
 
-        return columns
-    
-    @classmethod
-    def normalize(cls, results: list):
-        """
-        ensure results of db querries are dict before parsing
-        """
-        return [dict(r) for r in results]
+        return columns, link_tables
 
-    async def serialize(self, data: dict, insert: bool = False, alias=None):
+    async def serialize(
+        self: TDataBaseModel, 
+        data: dict, 
+        insert: bool = False,
+        update: bool = False,
+        alias=None
+    ) -> Tuple[dict, List[Awaitable]]:
         """
         expects
             `data` - data to be serialized
         """
+        database = self.__metadata__.database
+        name = self.__class__.__name__
         if not alias:
             alias = {}
 
         values = {**data}
+        primary_key = self.__metadata__.tables[name]['primary_key']
+        
+        link_chain = [] 
 
         for k, v in data.items():
             
-            name = self.__class__.__name__
             serialize = self.__metadata__.tables[name]['column_map'][k][2]
-
+            skip = False
             if k in self.__metadata__.tables[name]['foreign_keys']:
 
                 # use the foreign DataBaseModel's primary key / value 
                 foreign_type = self.__metadata__.tables[name]['column_map'][k][1]
-                foreign_primary_key = foreign_type.__metadata__.tables[foreign_type.__name__]['primary_key']
+                foreign_name = foreign_type.__name__
+                foreign_primary_key = foreign_type.__metadata__.tables[foreign_name]['primary_key']
+
+                link_table = self.__metadata__.tables[name]['relationships'][foreign_name][0]
                 
                 foreign_values = [v] if not isinstance(v, list) else v
                 fk_values = []
+                local_value = getattr(self, primary_key)
+
+                foreign_values = getattr(self, k)
+                if not isinstance(foreign_values, list):
+                    foreign_values = [foreign_values]
 
                 for v in foreign_values:
-                    foreign_model = foreign_type(**v)
-                    foreign_primary_key_value = getattr(foreign_model, foreign_primary_key)
+
+                    if v is None:
+                        continue
+                        
+                    if isinstance(v, foreign_type):
+                        v = v.dict()
+
+                    if isinstance(v, Callable):
+                        v = await v()
+                        v = v.dict()
+
+                    if isinstance(v, dict):
+                        foreign_primary_key_value = v[foreign_primary_key]
+                    else:
+                        foreign_primary_key_value = v
 
                     fk_values.append(foreign_primary_key_value)
                     
+                    serialize_local = self.__metadata__.tables[name]['column_map'][primary_key][2]
+                    serialize_foreign = self.__metadata__.tables[foreign_name]['column_map'][foreign_primary_key][2]
+
+                    
+                    if serialize_local:
+                        local_value = dumps(local_value)
+                    
+                    if serialize_foreign:
+                        foreign_primary_key_value = dumps(foreign_primary_key_value)
+
+                    link_values = {
+                        f'{name}_{primary_key}': local_value, 
+                        f'{foreign_name}_{foreign_primary_key}': foreign_primary_key_value
+                    }
+
+                    link_insert = database.execute(link_table.insert(), link_values)
+                    link_chain.append(link_insert)
+
                     if insert:
-                        exists = await foreign_type.exists(**{foreign_primary_key: foreign_primary_key_value})
-                        if not exists:
-                            await foreign_model.insert()
+                        exists = await foreign_type.filter(
+                            **{
+                                foreign_primary_key: foreign_primary_key_value,
+                                'count_rows': True,
+                                'join': False,
+                                },
+                        )
+                        if exists == 0:
+                            foreign_model = foreign_type(**v)
+                            link_chain.extend(await foreign_model.save(return_links=True))
+
                 del values[k]
 
-                values[f'fk_{foreign_type.__name__}_{foreign_primary_key}'.lower()] = fk_values[0] if not serialize else dumps(fk_values)
+                # delete links between items not in fk_values
 
+                if update and fk_values:
+                    link_chain.append(
+                        database.execute(
+                            delete(link_table).where(
+                                and_(
+                                    link_table.c[f'{name}_{primary_key}']==local_value,
+                                    link_table.c[f'{foreign_type.__name__}_{foreign_primary_key}'].not_in(fk_values)
+                                )
+                            )
+                        )
+                    )
+                
+                # remove existing references, if any, to match removed
+                if update and not fk_values:
+                    link_chain.append(
+                        database.execute(
+                            delete(link_table).where(
+                                link_table.c[f'{name}_{primary_key}']==local_value
+                            )
+                        )
+                    )
                 continue
             
             serialize = self.__metadata__.tables[name]['column_map'][k][2]
 
             if serialize:
                 values[k] = dumps(getattr(self, k))
+
                 continue
             values[k] = v
 
-        return values
+        return values, link_chain
 
-    async def save(self):
+    async def save(self: TDataBaseModel, return_links: bool = False) -> NoneType:
         primary_key = self.__metadata__.tables[self.__class__.__name__]['primary_key']
-        exists = await self.__class__.exists(
-            **{primary_key: getattr(self, primary_key)}
+        count = await self.__class__.filter(
+            **{primary_key: getattr(self, primary_key)},
+            count_rows=True
         )
-        if not exists:
-            return await self.insert()
-        return await self.update()
+        if count == 0:
+            return await self.insert(return_links=return_links)
+        print(f"{self.__class__.__name__} - updating")
+        await self.update()
+
+        if return_links:
+            return []
     
     @classmethod
-    def where(cls, query, where: dict, *conditions):
+    def where(
+        cls, query: Query, 
+        where: dict, 
+        *conditions: List[DataBaseModelCondition]
+    ) -> Tuple[Query, tuple]:
+
         table = cls.get_table()
         conditions = list(conditions)
+        values = []
 
-        
+        # convert keyword arguments into DataBaseModelConditions
         for cond, value in where.items():
+            is_serialized = cls.__metadata__.tables[cls.__name__]['column_map'][cond][2]
             if not isinstance(cond, DataBaseModelAttribute) and  hasattr(cls, cond):
                 cond = getattr(cls, cond)
+                conditions.append(cond == value)
+
             else:
                 raise Exception(f"{cond} is not a valid column in {table}")
             
-            conditions.append(cond == value)
+            
             query_value = value
             if cond.serialized:
                 query_value = dumps(value)
-        values = []
-        for condition in conditions:
-            query = query.where(condition.condition)
+        
+        for condition in conditions:               
+            try:
+                query = query.where(condition.condition) 
+            except Exception:
+                query = query.where(condition.condition.condition) 
             if isinstance(condition.values, tuple):
                 values.extend(condition.values)
 
         return query, tuple(values)
 
     @classmethod
-    def get_table(cls):
+    def get_table(cls)-> sqlalchemy.Table:
         if cls.__name__ not in cls.__metadata__.tables:
             cls.generate_sqlalchemy_table()
 
         return cls.__metadata__.tables[cls.__name__]['table']
 
     @classmethod
-    def OR(cls, *conditions, **filters) -> DataBaseModelCondition:
+    def OR(
+        cls, 
+        *conditions: List[DataBaseModelCondition], 
+        **filters: dict
+    ) -> DataBaseModelCondition:
+        """
+        combines input `conditions` and keyword argument filters
+        into an OR separated conditional tied with associated values
+        in a new `DataBaseModelCondition` 
+        """
         table = cls.get_table()
         conditions = list(conditions)
 
@@ -451,7 +701,7 @@ class DataBaseModel(BaseModel):
         
 
     @classmethod
-    def gt(cls, column, value) -> DataBaseModelCondition:
+    def gt(cls, column: str, value: Any) -> DataBaseModelCondition:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -463,7 +713,7 @@ class DataBaseModel(BaseModel):
         )
 
     @classmethod
-    def gte(cls, column, value) -> DataBaseModelCondition:
+    def gte(cls, column: str, value: Any) -> DataBaseModelCondition:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -475,7 +725,7 @@ class DataBaseModel(BaseModel):
         
 
     @classmethod
-    def lt(cls, column, value) -> DataBaseModelCondition:
+    def lt(cls, column: str, value: Any) -> DataBaseModelCondition:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -486,7 +736,7 @@ class DataBaseModel(BaseModel):
         )
 
     @classmethod
-    def lte(cls, column, value) -> DataBaseModelCondition:
+    def lte(cls, column: str, value: Any) -> DataBaseModelCondition:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -497,7 +747,11 @@ class DataBaseModel(BaseModel):
         )
 
     @classmethod
-    def contains(cls, column, value) -> DataBaseModelCondition:
+    def contains(cls, column: str, value: Any) -> DataBaseModelCondition:
+        """
+        returns a `DataBaseModelCondition` searching for `value` in a
+        `column`
+        """
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -509,14 +763,14 @@ class DataBaseModel(BaseModel):
         )
 
     @classmethod
-    def desc(cls, column):
+    def desc(cls, column) -> UnaryExpression:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
         return table.c[column].desc()
 
     @classmethod
-    def asc(cls, column):
+    def asc(cls, column) -> UnaryExpression:
         table = cls.get_table()
         if not column in table.c:
             raise Exception(f"{column} is not a valid column in {table}")
@@ -544,41 +798,116 @@ class DataBaseModel(BaseModel):
         results = await database.fetch(sel, cls.__name__, values)
 
         return bool(results)
+
+    @classmethod
+    def deep_join(
+        cls,
+        model_ref,
+        model_ref_primary_key: str,
+        column_ref: str,
+        session_query: Query,
+        tables_to_select: list,
+        models_selected: set,
+        root_model: TDataBaseModel = None,
+    ) -> Tuple[Query, List[Tuple[sqlalchemy.Table, TDataBaseModel, str, TDataBaseModel]]]:
+        """
+        Traverse a DataBaseModel relationship and add subsequent 
+        .join() clauses to active session_query, and append foreign tables
+        to list
+        """
+        if cls.__name__ in models_selected:
+            return session_query, tables_to_select
+
+        foreign_models = []
+        for column_name in cls.__metadata__.tables[cls.__name__]['column_map']:
+            if column_name in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
+            
+                # foreign model
+                foreign_model = cls.__metadata__.tables[cls.__name__]['column_map'][column_name][1]
+                if foreign_model.__name__ in models_selected:
+                    # skipping model, as is already selected in current query
+                    continue
+                foreign_models.append((foreign_model, column_name))
+                
+
+        ref_table = model_ref.get_table()
+        table = cls.get_table()
+        primary_key = cls.__metadata__.tables[cls.__name__]['primary_key']
         
+        link_table = cls.__metadata__.tables[model_ref.__name__]['relationships'][cls.__name__][0]
+        
+        session_query = session_query.outerjoin(
+            link_table, 
+            getattr(ref_table.c, model_ref_primary_key) == getattr(link_table.c, f"{model_ref.__name__}_{model_ref_primary_key}")
+        ).outerjoin(
+            table,
+            getattr(
+                link_table.c, 
+                f"{cls.__name__}_{primary_key}"
+            ) == getattr(
+                table.c, 
+                primary_key
+            )
+        )
+        if not cls is root_model:
+            session_query = session_query.add_columns(*[c for c in table.c])
+            tables_to_select.append((table, cls, column_ref, model_ref))
+        models_selected.add(cls.__name__)
+
+        for foreign_model, column_ref in foreign_models:
+            if foreign_model.__name__ in models_selected:
+                continue
+            session_query, tables_to_select = foreign_model.deep_join(
+                cls, primary_key, column_ref,
+                session_query, tables_to_select, models_selected
+            )
+        
+        return session_query, tables_to_select
+
     @classmethod
     async def select(cls,
-        *selection,
+        *selection: str,
         where: Optional[Union[dict, None]] = None,
         alias: Optional[dict] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = 0,
-        order_by = None
-    ) -> List[dict]:
+        order_by = None,
+        primary_key: str = None,
+        backward_refs: bool = True,
+    ) -> List[Optional[TDataBaseModel]]:
         if alias is None:
             alias = {}
 
         table = cls.get_table()
         database = cls.__metadata__.database
+        session = Session(database.engine)
+        
 
         if selection[0] == '*':
             selection = [k for k in cls.__metadata__.tables[cls.__name__]['column_map']]
 
-        #
-        items_to_select = []
+        tables_to_select = []
+        models_selected = set((cls.__name__,))
+
+        primary_key = cls.__metadata__.tables[cls.__name__]['primary_key'] if not primary_key else primary_key
+        sel = session.query(table)
+
         for _sel in selection:
             column_name = _sel
 
             if column_name in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
-                fk_name = cls.__metadata__.tables[cls.__name__]['foreign_keys'][column_name]
-                items_to_select.append(table.c[fk_name])
+                foreign_model = cls.__metadata__.tables[cls.__name__]['column_map'][column_name][1]
+                sel, tables_to_select = foreign_model.deep_join(
+                    cls, primary_key, column_name,
+                    sel, tables_to_select, models_selected,
+                    root_model = cls
+                )
+
                 continue
 
             if column_name not in table.c:
                 raise Exception(f"{column_name} is not a valid column in {table} - columns: {[k for k in table.c]}")
-            items_to_select.append(table.c[column_name])
-        #
-        sel = select(items_to_select)
-
+        
         values = None
         if where:
             sel, values = cls.where(sel, where)
@@ -588,60 +917,143 @@ class DataBaseModel(BaseModel):
         if order_by is not None:
             sel = sel.order_by(order_by)
 
-        decoded_results = []
+        results = await database.fetch(sel.statement, cls.__name__, values)
         
-        results = await database.fetch(sel, cls.__name__, values)
+        # build results_map
+        results_map = {}
+        last_ind = -1
+        for i, c in enumerate(table.c):
+            col_name = c.name if not c.name in alias else alias[c.name]
+            last_ind = last_ind + 1
+            if c.name in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
+                continue
+            if not cls in results_map:
+                results_map[cls] = {}
+            results_map[cls][col_name] = last_ind
 
-        for result in cls.normalize(results):
-            values = {}
-            for sel, value in zip(selection, result):
-                serialized = cls.__metadata__.tables[cls.__name__]['column_map'][sel][2]
-
-                if sel in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
-
-                    foreign_type = cls.__metadata__.tables[cls.__name__]['column_map'][sel][1]
-                    foreign_primary_key = foreign_type.__metadata__.tables[foreign_type.__name__]['primary_key']
-
-                    foreign_primary_key_values = loads(result[value]) if serialized else [result[value]]
-                    values[sel] = []
-                    for foreign_primary_key_value in foreign_primary_key_values:
-                        fk_query_results = await foreign_type.select(
-                            '*', 
-                            where={foreign_primary_key: foreign_primary_key_value},
-                        )
-                        values[sel].extend(fk_query_results)
-                    if serialized:
-                        values[sel] = values[sel]
-                        continue
-
-                    values[sel] = values[sel][0] if values[sel] else None
-                    continue 
-
-                if serialized:
-                    try:
-                        values[sel] = loads(result[value])
-                    except AttributeError as e:
-                        resolve_missing_attribute(
-                            str(repr(e))
-                        )
-                        values[sel] = loads(result[value])
-                    
+        for f_table, f_model, _, _ in tables_to_select:
+            for i, c in enumerate(f_table.c):
+                last_ind = last_ind + 1
+                if c.name in cls.__metadata__.tables[f_model.__name__]['foreign_keys']:
                     continue
+                if not f_model in results_map:
+                    results_map[f_model] = {}
+                results_map[f_model][c.name] = last_ind
 
-                values[sel] = result[value]
+        tables_to_select.reverse()
 
-                if sel in alias:
-                    values[alias[sel]] = values.pop(sel)
-            
-            if values:
-                decoded_results.append(
-                    cls(**values)
-                )
+        decoded_results = {}
+        row_results = {}
 
-        return decoded_results
+        for result in results:
+            if isinstance(result, dict):
+                result = tuple(result.values())
+
+            result_key = result[results_map[cls][primary_key]]
+
+
+            if not result_key in decoded_results:
+                decoded_results[result_key] = {}
+                row_results = {}
+
+                for k, result_ind in results_map[cls].items():
+                    serialized = cls.__metadata__.tables[cls.__name__]['column_map'][k][2]
+                    is_array = cls.__metadata__.tables[cls.__name__]['column_map'][k][3]
+                    row_result = result[result_ind]
+                    if serialized:
+                        row_result = deserialize(row_result)
+
+                        if type(row_result) in {set, list, tuple} and is_array:
+                            decoded_results[result_key][k] = row_result
+                            continue
+
+                        decoded_results[result_key][k] = row_result
+
+                    if is_array:
+                        if not k in decoded_results[result_key]:
+                            decoded_results[result_key][k] = []
+                        
+                        decoded_results[result_key][k].append(row_result)
+                    else:
+                        decoded_results[result_key][k] = row_result
+
+            for f_table, f_model, column_name, parent in tables_to_select:
+                f_p_key = cls.__metadata__.tables[f_model.__name__]['primary_key']
+                f_p_key_value = result[results_map[f_model][f_p_key]]
+                new_data = False
+                if not row_results.get(f_p_key) == f_p_key_value:
+                    new_data = True
+                    for k, result_ind in results_map[f_model].items():
+                        
+                        serialized = cls.__metadata__.tables[f_model.__name__]['column_map'][k][2]
+                        is_array = cls.__metadata__.tables[f_model.__name__]['column_map'][k][3]
+                        row_result = result[result_ind]
+
+                        if serialized:
+                            row_result = deserialize(row_result) if not row_result is None else None
+                            row_results[k] = row_result
+                                
+                        elif is_array:
+                            if not k in row_results and not k == f_p_key:
+                                row_results[k] = []
+                            if row_result:
+                                row_results[k].append(row_result)
+                        else:
+                            row_results[k] = row_result
+
+                # build model with collected results
+                is_array_in_parent = parent.__metadata__.tables[parent.__name__]['column_map'][column_name][3]
+
+                parent_p_key = parent.__metadata__.tables[parent.__name__]['primary_key']
+                parent_p_key_val = result[results_map[parent][parent_p_key]]
+
+                try:
+                    model_ins = f_model(**row_results)
+                    for k in cls.__metadata__.tables[f_model.__name__]['foreign_keys']:
+                        foreign_ref = getattr(model_ins, k)
+                        try:
+                            if backward_refs and  (foreign_ref is None or (isinstance(foreign_ref, list) and foreign_ref == [])):
+                                setattr(model_ins, k, RelationshipRef(parent, parent_p_key, parent_p_key_val))
+                        except Exception as e:
+                            breakpoint()
+
+                except ValidationError:
+                    model_ins = None
+                        
+                if is_array_in_parent:
+                    
+                    if not column_name in row_results:
+                        row_results[column_name] = []
+                    if not column_name in decoded_results[result_key]:
+                        decoded_results[result_key][column_name] = []
+                    if model_ins and new_data:
+                        decoded_results[result_key][column_name].append(model_ins)
+                        row_results[column_name].append(model_ins)
+                    elif model_ins and row_results[column_name]:
+                        row_results[column_name][-1] = model_ins
+                        decoded_results[result_key][column_name][-1] = model_ins
+                    elif model_ins:
+                        row_results[column_name].append(model_ins)
+                        decoded_results[result_key][column_name].append(model_ins)
+                else:
+                    row_results[column_name] = model_ins
+                    decoded_results[result_key][column_name] = row_results[column_name]
+        
+        parsed_results = [
+            cls(**decoded_results[pk]) for pk in decoded_results
+
+        ]
+
+        return parsed_results
 
     @classmethod
-    def check_limit_offset(cls, query, values, limit, offset):
+    def check_limit_offset(
+        cls, 
+        query: Query, 
+        values: List[Any], 
+        limit: int, 
+        offset: int
+    ) -> Tuple[Query, list]:
         values = list(values) if values else []
 
         if limit:
@@ -663,7 +1075,7 @@ class DataBaseModel(BaseModel):
         limit: int = None, 
         offset: int = 0,
         order_by = None
-    ):
+    ) -> List[Optional[TDataBaseModel]]:
         parameters = {}
         if limit:
             parameters['limit'] = limit
@@ -675,94 +1087,203 @@ class DataBaseModel(BaseModel):
         return await cls.select('*', **parameters)
 
     @classmethod
-    async def count(cls):
+    async def count(cls) -> int:
         table = cls.get_table()
         database = cls.__metadata__.database
-        sel = select([func.count()]).select_from(table)
-        results = await database.fetch(sel, cls.__name__)
+        session = Session(database.engine)
+        sel = session.query(func.count()).select_from(table)
+        results = await database.fetch(sel.statement, cls.__name__)
         return results[0][0] if results else 0
 
     @classmethod
     async def filter(
         cls, 
-        *conditions, 
+        *conditions: List[DataBaseModelCondition], 
         limit: int = None, 
         offset: int = 0,
         order_by = None, 
         count_rows: bool = False,
-        **column_filters
-    ):
+        join: bool = True,
+        backward_refs: bool = True,
+        **column_filters: dict
+    ) -> List[Optional[TDataBaseModel]]:
         table = cls.get_table()
         database = cls.__metadata__.database
+        session = Session(database.engine)
 
         columns = [k for k in cls.__fields__]
         if not column_filters and not conditions:
             raise Exception(f"{cls.__name__}.filter() expects keyword arguments for columns: {columns} or conditions")
-        sel = table.select() if not count_rows else select([func.count()]).select_from(table)
+
+
+        selection = [k for k in cls.__metadata__.tables[cls.__name__]['column_map']]
+        
+        tables_to_select = []
+        models_selected = set((cls.__name__,))
+
+        primary_key = cls.__metadata__.tables[cls.__name__]['primary_key']
+        sel = session.query(table)
+
+
+        for _sel in selection:
+            column_name = _sel
+            if column_name in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
+                foreign_model = cls.__metadata__.tables[cls.__name__]['column_map'][column_name][1]
+                if not join:
+                    continue
+                sel, tables_to_select = foreign_model.deep_join(
+                    cls, primary_key, column_name,
+                    sel, tables_to_select, models_selected
+                )
+                continue
 
         sel, values = cls.where(sel, column_filters, *conditions)
 
-        sel, values = cls.check_limit_offset(sel, values, limit, offset)
+        sel, values = cls.check_limit_offset(sel.statement, values, limit, offset)
         
         if count_rows:
-            row_count = await database.fetch(sel, cls.__name__)
-            return row_count[0][0] if row_count else 0
+            row_count = await database.fetch(sel.with_only_columns(func.count()), cls.__name__)
+            if row_count:
+                if isinstance(row_count[0], dict):
+                    return [v for _, v in row_count[0].items()][0]
+                return row_count[0][0]
+            return 0
 
         if not order_by is None:
             sel = sel.order_by(order_by)
 
         results = await database.fetch(sel, cls.__name__, tuple(values))
 
-        normalized_results = cls.normalize(results)
+        results_map = {}
+        last_ind = -1
+        for i, c in enumerate(table.c):
+            last_ind = last_ind + 1
+            if c.name in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
+                continue
+            if not cls in results_map:
+                results_map[cls] = {}
+            results_map[cls][c.name] = last_ind
 
-        rows = []
-        for result in cls.normalize(results):
-            values = {}
-            for sel, value in zip(columns, result):
-                serialized = cls.__metadata__.tables[cls.__name__]['column_map'][sel][2]
-
-                if sel in cls.__metadata__.tables[cls.__name__]['foreign_keys']:
-                    foreign_type = cls.__metadata__.tables[cls.__name__]['column_map'][sel][1]
-                    foreign_primary_key = foreign_type.__metadata__.tables[foreign_type.__name__]['primary_key']
-                    result[value] = loads(result[value]) if serialized else [result[value]]
-
-                    foreign_values = []
-                    for foreign_pkey in result[value]:
-                        foreign_result = await foreign_type.select(
-                            '*', where={foreign_primary_key: foreign_pkey}
-                        )
-                        foreign_values.extend(foreign_result)
-                    
-                    if serialized:
-                        values[sel] = foreign_values
-                        continue
-
-                    values[sel] =  foreign_values[0] if foreign_values else None
-                    continue 
-                
-                
-                if serialized:
-                    try:
-                        values[sel] = loads(result[value])
-                    except AttributeError as e:
-                        resolve_missing_attribute(
-                            str(repr(e))
-                        )
-                        values[sel] = loads(result[value])
+        for f_table, f_model, _, _ in tables_to_select:
+            for i, c in enumerate(f_table.c):
+                last_ind = last_ind + 1
+                if c.name in cls.__metadata__.tables[f_model.__name__]['foreign_keys']:
                     continue
-                values[sel] = result[value]
-            try:
-                rows.append(
-                    cls(**values)
-                )
-            except Exception as e:
-                pass
-        return rows
+                if not f_model in results_map:
+                    results_map[f_model] = {}
+                results_map[f_model][c.name] = last_ind
+
+        tables_to_select.reverse()
+        decoded_results = {}
+        row_results = {}
+
+        for result in results:
+            if isinstance(result, dict):
+                result = tuple(result.values())
+
+            result_key = result[results_map[cls][primary_key]]
+
+
+            if not result_key in decoded_results:
+                decoded_results[result_key] = {}
+                row_results = {}
+
+                for k, result_ind in results_map[cls].items():
+                    serialized = cls.__metadata__.tables[cls.__name__]['column_map'][k][2]
+                    is_array = cls.__metadata__.tables[cls.__name__]['column_map'][k][3]
+                    row_result = result[result_ind]
+                    if serialized:
+                        row_result = deserialize(row_result)
+                        row_results[k] = row_result
+                        decoded_results[result_key][k] = row_result
+
+                    elif is_array:
+                        if not k in decoded_results[result_key]:
+                            decoded_results[result_key][k] = []
+                        
+                        decoded_results[result_key][k].append(row_result)
+                    else:
+                        decoded_results[result_key][k] = row_result
+
+            for f_table, f_model, column_name, parent in tables_to_select:
+                f_p_key = cls.__metadata__.tables[f_model.__name__]['primary_key']
+                f_p_key_value = result[results_map[f_model][f_p_key]]
+                new_data = False
+                if not row_results.get(f_p_key) == f_p_key_value:
+                    new_data = True
+                    for k, result_ind in results_map[f_model].items():
+                        
+                        serialized = cls.__metadata__.tables[f_model.__name__]['column_map'][k][2]
+                        is_array = cls.__metadata__.tables[f_model.__name__]['column_map'][k][3]
+                        row_result = result[result_ind]
+
+                        if serialized:
+                            row_result = deserialize(row_result) if not row_result is None else None
+
+                            if isinstance(row_result, list) and is_array:
+                                row_results[k] = row_result
+                                
+                        elif is_array:
+                            if not k in row_results and not k == f_p_key:
+                                row_results[k] = []
+                            if row_result:
+                                row_results[k].append(row_result)
+                        else:
+                            row_results[k] = row_result
+
+                # build model with collected results
+                is_array_in_parent = parent.__metadata__.tables[parent.__name__]['column_map'][column_name][3]
+
+                parent_p_key = parent.__metadata__.tables[parent.__name__]['primary_key']
+                parent_p_key_val = result[results_map[parent][parent_p_key]]
+
+                try:
+                    model_ins = f_model(**row_results)
+                    for k in cls.__metadata__.tables[f_model.__name__]['foreign_keys']:
+                        foreign_ref = getattr(model_ins, k)
+                        if backward_refs and  (foreign_ref is None or foreign_ref == []):
+                            setattr(model_ins, k, RelationshipRef(parent, parent_p_key, parent_p_key_val))
+                except ValidationError:
+                    model_ins = None
+                        
+                if is_array_in_parent:
+                    if not column_name in row_results:
+                        row_results[column_name] = []
+                    if not column_name in decoded_results[result_key]:
+                        decoded_results[result_key][column_name] = []
+                    if model_ins and new_data:
+                        decoded_results[result_key][column_name].append(model_ins)
+                        row_results[column_name].append(model_ins)
+                    elif model_ins and row_results[column_name]:
+                        row_results[column_name][-1] = model_ins
+                        decoded_results[result_key][column_name][-1] = model_ins
+                    elif model_ins:
+                        row_results[column_name].append(model_ins)
+                        decoded_results[result_key][column_name].append(model_ins)
+                else:
+                    row_results[column_name] = model_ins
+                    decoded_results[result_key][column_name] = row_results[column_name]
+
+        parsed_results = [
+            cls(**decoded_results[pk]) for pk in decoded_results
+        ]
+        return parsed_results
 
     async def update(self,
         where: dict = None,
-        **to_update
-    ):
+        **to_update: Optional[dict]
+    ) -> NoneType:
+        """
+        <b>Update<b>
+        Updates the contents of a `DataBaseModel` instance in the database
+            where the value of `DataBaseModel` primary key matches 
+        ```
+            models = await Model.filter(Model.id='abcd1234')
+            model = models[0]
+            model.data = '12345'
+            await model.update()
+        ```
+        """
         self.__class__.get_table()
 
         table_name = self.__class__.__name__
@@ -784,56 +1305,114 @@ class DataBaseModel(BaseModel):
                 raise Exception(f"{column} is not a valid column in {table}")
 
         query, _ = self.where(table.update(), where_)
-        
-        to_update = await self.serialize(to_update, insert=True)
 
-        query = query.values(**to_update)
+        to_update, links = await self.serialize(to_update, insert=True, update=True)
 
-        await self.__metadata__.database.execute(query, to_update)
+        if to_update:
+            query = query.values(**to_update)
+            await self.__metadata__.database.execute(query, to_update)
+        if links:
+            try:
+                await asyncio.gather(*[asyncio.shield(l) for l in links])
+            except Exception as e:
+                print(repr(e))
 
             
-    async def delete(self):
+    async def delete(self) -> NoneType:
+        """
+        <b>Delete<b>
+        Delete the contents of a `DataBaseModel` instance in the database
+            where the value of `DataBaseModel` primary key matches 
+        ```
+            models = await Model.filter(Model.id='abcd1234')
+            model = models[0]
+            await model.delete()
+        ```
+        """
         table_name = self.__class__.__name__
-        table = self.__metadata__.tables[table_name]['table']
-        primary_key = self.__metadata__.tables[table_name]['primary_key']
-
-        query, _ = self.where(table.delete(table), {primary_key: getattr(self, primary_key)})
-
-        return await self.__metadata__.database.execute(query, None)
-    
-    async def insert(self):
-        table = self.__class__.get_table()
+        database = self.__metadata__.database
         
-        values = await self.serialize(self.dict(), insert=True)
-        query = table.insert()
+        table = self.__metadata__.tables[table_name]['table']
 
-        return await self.__metadata__.database.execute(
-            query, values
-        )
+        primary_key = self.__metadata__.tables[table_name]['primary_key']
+        
+        query, _ = self.where(delete(table), {primary_key: getattr(self, primary_key)})
+
+        return await database.execute(query, None)
+
+    async def insert(
+        self, 
+        return_links=False
+    ) -> Union[NoneType, List[Coroutine]]:
+        """
+        <b>Insert<b>
+        Insert the contents of a `DataBaseModel` instance in the database
+            if the values of the `DataBaseModel` primary key do not exist 
+        ```
+        model = Models(id='abcd1234', data='data')
+        await model.insert()
+        ```
+        Internal Only:
+            return_links - will request table_link insertions be returned to 
+                run later, needed when inserting `DataBaseModel`s with related
+                `DataBaseModel` attributes
+        """
+        table = self.__class__.get_table()
+        database = self.__metadata__.database
+
+        values, links = await self.serialize(self.dict(), insert=True)
+        query = table.insert()
+        try:
+            await self.__metadata__.database.execute(
+                query, values
+            )
+        except Exception as e:
+            database.log.error(f"error inserting into {table.name} - error: {repr(e)}")
+            for link in links:
+                link.close()
+            raise e
+            
+        if return_links:
+            return links
+
+        # run links in chain
+        try:
+            await asyncio.gather(*[asyncio.shield(l) for l in links])
+        except Exception:
+            database.log.exception(f"chain link insertion error")
+
 
     @classmethod
-    async def get(cls, *p_key_condition, **p_key):
+    async def get(
+        cls, 
+        *p_key_condition: DataBaseModelCondition, 
+        backward_refs=True,
+        **p_key: dict
+    ) -> TDataBaseModel:
         if not p_key_condition:
             for k in p_key:
                 primary_key = cls.__metadata__.tables[cls.__name__]['primary_key']
                 if k != cls.__metadata__.tables[cls.__name__]['primary_key']:
-                    raise f"Expected primary key {primary_key}=<value>"
+                    raise Exception(f"Expected primary key {primary_key}=<value>")
                 p_key_condition = [getattr(cls, primary_key)  == p_key[k]]
             
-        result = await cls.filter(*p_key_condition)
+        result = await cls.filter(*p_key_condition, backward_refs=backward_refs)
         return result[0] if result else None
 
     @classmethod
-    async def create(cls, **column_args):
-        new_obj = cls(**column_args)
+    async def create(cls, **model_kwargs) -> TDataBaseModel:
+        new_obj = cls(**model_kwargs)
         await new_obj.insert()
         return new_obj
+    def __init__(self, **model_kwargs) -> TDataBaseModel:
+        return super().__init__(**model_kwargs)
 
 
 class TableMeta(DataBaseModel):
     table_name: str = PrimaryKey()
     model: dict
     columns: list
+
 
 class DatabaseInit(DataBaseModel):
     database_url: str = PrimaryKey()

--- a/pydbantic/core.py
+++ b/pydbantic/core.py
@@ -39,8 +39,8 @@ class RelationshipRef(BaseModel):
     def __call__(self) -> Coroutine:
         return self._method_()
 
-    def _get_value(self):
-        return self._default_
+    # def _get_value(self):
+    #     return self._default_
 
     def dict(self, *args, **kwargs):
         return {f"{self.primary_key}": self.value}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+log_cli=true

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,10 +1,11 @@
 pytest
 pytest-asyncio
 uvloop==0.16.0
+nest-asyncio==1.5.4
 fastapi==0.68.1
 requests==2.26.0
 psycopg2==2.9.1
 PyMySQL==0.9.3
 aiomysql==0.0.21
 cryptography==3.4.8
-mysqlclient==2.0.3
+mysqlclient==2.0.3  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 SQLAlchemy==1.4.28
-databases==0.4.3 
+databases==0.5.3
 aioredis==2.0.0 
 pydantic==1.8.2
 asyncpg==0.24.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-SQLAlchemy==1.3.24 
+SQLAlchemy==1.4.28
 databases==0.4.3 
 aioredis==2.0.0 
 pydantic==1.8.2

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 import setuptools
 
 BASE_REQUIREMENTS = [
-    'SQLAlchemy==1.3.24', 
-    'databases==0.4.3', 
+    'SQLAlchemy==1.4.28',
+    'databases==0.5.3', 
     'aioredis==2.0.0', 
     'pydantic==1.8.2',
 ]
 MYSQL_REQUIREMENTS = [
+    'aiomysql==0.0.21',
     'cryptography==3.4.8',
     'mysqlclient==2.0.3',
     'PyMySQL==0.9.3',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ from tests.models import Department, Employee, EmployeeInfo, Positions
 
 DB_PATH = {
     'sqlite': 'sqlite:///test.db',
-    'mysql': 'mysql://josh:abcd1234@127.0.0.1/auth-db',
+    'mysql': 'mysql://josh:abcd1234@127.0.0.1/database',
     'postgres': 'postgresql://postgres:abcd1234@localhost/database'
 }
 
@@ -71,6 +71,7 @@ async def database_with_cache(request):
     yield db, Employee
     db.metadata.drop_all()
 
+    await db.cache.redis.flushall()
     await db.cache.redis.close()
 
 @pytest.fixture()

--- a/tests/migrations/test_model_migration_3.py
+++ b/tests/migrations/test_model_migration_3.py
@@ -4,6 +4,10 @@ from pydbantic import Database
 
 @pytest.mark.asyncio
 async def test_model_migrations_3_new(new_model_2, db_url):
+    """
+    test migration when a colunn is renamed
+    b -> b_new
+    """
     Data = new_model_2
     db = await Database.create(
         db_url,

--- a/tests/migrations/test_model_migration_4.py
+++ b/tests/migrations/test_model_migration_4.py
@@ -15,4 +15,4 @@ async def test_model_migrations_4_new(new_model_3, db_url):
         )
         assert False, f"Migration should have failed due to primary key UNIQUE constraint failed: Data.d"
     except Exception as e:
-        assert True
+        assert not isinstance(e, AssertionError)

--- a/tests/migrations/test_model_migration_8.py
+++ b/tests/migrations/test_model_migration_8.py
@@ -1,0 +1,44 @@
+from logging import exception
+import time
+import uuid
+from typing import Optional
+from attr import has
+import pytest
+
+
+from pydbantic import Database, DataBaseModel, PrimaryKey, Default
+from pydantic import BaseModel
+
+def get_uuid():
+    return str(uuid.uuid4())
+
+class Related(DataBaseModel):
+    f: str = PrimaryKey(default=get_uuid)
+    g: str = 'abcd1234'
+
+class SubData(BaseModel):
+    a: int = 1
+    b: float = 1.0
+
+class Data(DataBaseModel):
+    a: int
+    b_new: float
+    c: str
+    d: list
+    e: str = PrimaryKey(default=get_uuid)
+    i: str
+    sub: SubData = None
+    related: Optional[Related] = None
+
+@pytest.mark.asyncio
+async def test_model_migrations_8_new(db_url):
+    db = await Database.create(
+        db_url,
+        tables=[Data],
+        cache_enabled=False
+    )
+    data_items = await Data.all()
+    for data in data_items:
+        assert hasattr(data, 'related')
+
+    assert len(data_items) == 10

--- a/tests/migrations/test_model_migration_9.py
+++ b/tests/migrations/test_model_migration_9.py
@@ -1,0 +1,74 @@
+from logging import exception
+import time
+import random
+import uuid
+from typing import Optional, List
+from attr import has
+import pytest
+
+
+from pydbantic import Database, DataBaseModel, PrimaryKey, Default
+from pydantic import BaseModel
+
+def get_uuid():
+    return str(uuid.uuid4())
+
+def get_random_name():
+    return f"{get_uuid()}_{random.choice(['joe', 'john', 'bill'])}"
+
+class Ancestor(DataBaseModel):
+    name: str = PrimaryKey()
+    relatives: List['Related'] = []
+
+class Related(DataBaseModel):
+    f: str = PrimaryKey(default=get_uuid)
+    g: str = 'abcd1234'
+    parents: List[Ancestor] = []
+
+class SubData(BaseModel):
+    a: int = 1
+    b: float = 1.0
+
+class Data(DataBaseModel):
+    a: int
+    b_new: float
+    c: str
+    d: list
+    e: str = PrimaryKey(default=get_uuid)
+    i: str
+    sub: SubData = None
+    related: Optional[Related] = None
+
+@pytest.mark.asyncio
+async def test_model_migrations_9_new(db_url):
+    db = await Database.create(
+        db_url,
+        tables=[Data, Related, Ancestor],
+        cache_enabled=False
+    )
+    data_items = await Data.all()
+    ancestor = Ancestor(name=f"{get_random_name()}")
+
+    for data in data_items:
+        assert hasattr(data, 'related')
+        assert hasattr(data.related, 'parents')
+        assert len(data.related.parents) == 0 # should not be a RelationshipRef
+        
+        data.related.parents.append(
+            ancestor
+        )
+        await data.related.save()
+    
+    assert len(data_items) == 10
+
+    data_items = await Data.all()
+
+    for data in data_items:
+        assert hasattr(data, 'related')
+        assert hasattr(data.related, 'parents')
+        assert len(data.related.parents) == 1
+    
+    ancestor = await Ancestor.all()
+    assert len(ancestor) == 1
+
+    assert len(ancestor[0].relatives) == 10

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 from datetime import datetime
 from typing import List, Optional
-from pydbantic import DataBaseModel, PrimaryKey, Default, Relationship
+from pydbantic import DataBaseModel, PrimaryKey
 
 class Department(DataBaseModel):
     department_id: str 

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,19 +1,20 @@
 from uuid import uuid4
 from datetime import datetime
-from typing import List, Optional, Union
-from pydantic import BaseModel, Field
-from pydbantic import DataBaseModel, PrimaryKey, Default
+from typing import List, Optional
+from pydbantic import DataBaseModel, PrimaryKey, Default, Relationship
 
 class Department(DataBaseModel):
-    id: str 
+    department_id: str 
     name: str
     company: str
     is_sensitive: bool = False
+    positions: List[Optional['Positions']] = []
 
 class Positions(DataBaseModel):
-    id: str
+    position_id: str
     name: str
-    department: Department
+    department: Department = None
+    employees: List[Optional['Employee']] = []
 
 class EmployeeInfo(DataBaseModel):
     #__renamed__= [{'old_name': 'first_name', 'new_name': 'first_names'}]
@@ -25,11 +26,12 @@ class EmployeeInfo(DataBaseModel):
     city: Optional[str]
     zip: Optional[int]
     new: Optional[str]
+    employee: Optional['Employee'] = None
 
 class Employee(DataBaseModel):
-    id: str = PrimaryKey()
-    employee_info: Optional[EmployeeInfo]
-    position: Positions
+    employee_id: str = PrimaryKey()
+    employee_info: Optional[EmployeeInfo] = None
+    position: List[Optional[Positions]] = []
     salary: float
     is_employed: bool
     date_employed: Optional[str]
@@ -39,11 +41,12 @@ def time_now():
 def get_uuid4():
     return str(uuid4())
 
+
 class Coordinate(DataBaseModel):
-    time: str = PrimaryKey(default=time_now)
-    latitude: float
-    longitude: float
+    id: str = PrimaryKey(default=get_uuid4)
+    lat_long: tuple
+    journeys: List[Optional["Journey"]] = []
 
 class Journey(DataBaseModel):
     trip_id: str = PrimaryKey(default=get_uuid4)
-    waypoints: List[Optional[Coordinate]]
+    waypoints: List[Optional[Coordinate]] = []

--- a/tests/models/__init__.py
+++ b/tests/models/__init__.py
@@ -1,6 +1,6 @@
 from uuid import uuid4
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 from pydbantic import DataBaseModel, PrimaryKey
 
 class Department(DataBaseModel):
@@ -26,7 +26,7 @@ class EmployeeInfo(DataBaseModel):
     city: Optional[str]
     zip: Optional[int]
     new: Optional[str]
-    employee: Optional['Employee'] = None
+    employee: Optional[Union['Employee', dict]] = None
 
 class Employee(DataBaseModel):
     employee_id: str = PrimaryKey()

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,13 +1,13 @@
 import time
 import pytest
 from pydbantic import Database
-from tests.models import Employee
+from tests.models import Employee, Positions, Department
 
 @pytest.mark.asyncio
 async def test_database(db_url):
     db = await Database.create(
         db_url,
-        tables=[Employee],
+        tables=[Employee, Positions, Department],
         cache_enabled=False,
         testing=True
     )
@@ -16,7 +16,7 @@ async def test_database(db_url):
     result = await Employee.select('*')
 
     new_employee = {
-        'id': 'abcd1632173531.8840718', 
+        'employee_id': 'abcd1632173531.8840718', 
         'employee_info': {
             'ssn': '1234', 
             'first_name': 'new name - updated', 
@@ -24,15 +24,15 @@ async def test_database(db_url):
             'address': '123 lane', 
             'address2': None, 'city': None, 'zip': None
         }, 
-        'position': {
-            'id': '1234', 
+        'position': [{
+            'position_id': '1234', 
             'name': 'manager', 
             'department': {
-                'id': '5678', 
+                'department_id': '5678', 
                 'name': 'hr', 
                 'company': 'abc company', 
                 'is_sensitive': False
-            }}, 
+            }}], 
         'salary': 0.0, 
         'is_employed': False, 
         'date_employed': None
@@ -41,31 +41,31 @@ async def test_database(db_url):
     employee = Employee(**new_employee)
     await employee.insert()
 
-    result = await Employee.select('*', where={'id': employee.id})
+    result = await Employee.select('*', where={'employee_id': employee.employee_id})
 
     result = await Employee.select('*')
 
     await employee.delete()
 
-    result = await Employee.select('*', where={'id': employee.id})
+    result = await Employee.select('*', where={'employee_id': employee.employee_id})
 
-    result = await Employee.select('*', where={'id': employee.id})
+    result = await Employee.select('*', where={'employee_id': employee.employee_id})
 
-    result = await Employee.select('*', where={'id': employee.id})
+    result = await Employee.select('*', where={'employee_id': employee.employee_id})
 
     for i in range(21, 40):
         i = int(time.time()) + i
-        position = new_employee['position']
-        position['id'] = f'p{i}'
+        position = new_employee['position'][0]
+        position['employee_id'] = f'p{i}'
         row = Employee(
-            id=f'a{i}',
-            position=position,
+            employee_id=f'a{i}',
+            position=[position],
             is_employed=True, 
             salary=new_employee['salary'], 
             employee_info=new_employee['employee_info'],
         )
         await row.insert()
-    employees = await Employee.select('*', where={'id': row.id})
+    employees = await Employee.select('*', where={'employee_id': row.employee_id})
     
     filtered_employee = await Employee.filter(is_employed=True)
     assert len(filtered_employee) > 0
@@ -77,7 +77,5 @@ async def test_database(db_url):
 
     filtered_employee = await Employee.filter(is_employed=False)
     assert len(filtered_employee) == 1
-
-    Employee.__metadata__.tables['Employee']['table'].drop()
     
     db.metadata.drop_all()

--- a/tests/test_integration_fastapi.py
+++ b/tests/test_integration_fastapi.py
@@ -13,15 +13,13 @@ def test_fastapi_integration(fastapi_app_with_loaded_database):
         current_employees = response.json()
 
         for employee in current_employees:
-            Employee(**employee)
-        
-        # # send new model to api_router
-        # for employee in current_employees:
-        #     new_employee = employee.copy() 
-        #     new_employee['id'] = f'{new_employee["id"]}_new_{time.time()}'
-        #     response = client.post('/employee/create', json=new_employee)
-            
-        #     assert response.status_code == 200
+            del employee['employee_info']['employee']
+            del employee['position'][0]['employees']
+            del employee['position'][0]['department']['positions']
+            try:
+                Employee(**employee)
+            except Exception as e:
+                breakpoint()
         
         response = client.get('/employees')
         assert response.status_code == 200
@@ -31,9 +29,13 @@ def test_fastapi_integration(fastapi_app_with_loaded_database):
         assert len(employees) == 200
 
         for employee in employees:
+            del employee['employee_info']['employee']
+            del employee['position'][0]['employees']
+            del employee['position'][0]['department']['positions']
+
             new_employee = Employee(**employee)
         
-            new_employee.id = f'{employee["id"]}_new_{time.time()}'
+            new_employee.employee_id = f'{employee["employee_id"]}_new_{time.time()}'
             response = client.post('/employee', json=new_employee.dict())
             assert response.status_code == 200
     
@@ -47,9 +49,12 @@ def test_fastapi_integration(fastapi_app_with_loaded_database):
 
         # verify bad input
         for employee in employees:
+            del employee['employee_info']['employee']
+            del employee['position'][0]['employees']
+            del employee['position'][0]['department']['positions']
             Employee(**employee)
         
-            employee['id'] = f'{employee["id"]}_new_{time.time()}'
+            employee['employee_id'] = f'{employee["employee_id"]}_new_{time.time()}'
             employee['is_employed'] = 'not a bool'
             response = client.post('/employee', json=employee)
 

--- a/tests/test_integration_fastapi.py
+++ b/tests/test_integration_fastapi.py
@@ -1,10 +1,12 @@
 import time
 import pytest
 from fastapi.testclient import TestClient
-from tests.models import Employee
 
-def test_fastapi_integration(fastapi_app_with_loaded_database):
+@pytest.mark.asyncio
+async def test_fastapi_integration(fastapi_app_with_loaded_database):
     with TestClient(fastapi_app_with_loaded_database) as client:
+
+        from tests.models import Employee, Department, Positions, EmployeeInfo
 
         response = client.get('/employees')
         
@@ -27,6 +29,10 @@ def test_fastapi_integration(fastapi_app_with_loaded_database):
         employees = response.json()
 
         assert len(employees) == 200
+
+        emps = await Employee.all()
+        pos = await Positions.all()
+        deps = await Department.all()
 
         for employee in employees:
             del employee['employee_info']['employee']

--- a/tests/test_model_1_to_1.py
+++ b/tests/test_model_1_to_1.py
@@ -1,0 +1,19 @@
+import pytest
+from tests.models import EmployeeInfo, Employee
+
+@pytest.mark.asyncio
+async def test_model_filtering_operators(loaded_database_and_model):
+    db = loaded_database_and_model
+
+    all_employees = await Employee.all()
+    employee = all_employees[0]
+
+    employee_info = await EmployeeInfo.get(
+        EmployeeInfo.ssn == employee.employee_info.ssn
+    )
+    
+    assert employee_info.employee.employee_id == employee.employee_id
+    assert employee_info.employee.is_employed == employee.is_employed
+    assert employee_info.employee.salary == employee.salary
+    assert employee_info.employee.date_employed == employee.date_employed
+

--- a/tests/test_model_advanced.py
+++ b/tests/test_model_advanced.py
@@ -1,4 +1,5 @@
 import time
+from typing import Coroutine
 import pytest
 from pydbantic import Database
 from tests.models import Journey, Coordinate
@@ -7,38 +8,57 @@ from tests.models import Journey, Coordinate
 async def test_database(db_url):
     await Database.create(
         db_url,
-        tables=[Journey],
+        tables=[Journey, Coordinate],
         cache_enabled=False,
         testing=True
     )
 
     journey = await Journey.create(
-        waypoints=[Coordinate(latitude=1.0, longitude=1.0), Coordinate(latitude=1.0, longitude=1.0)]
+        waypoints=[]
     )
 
+
+    await Coordinate.create(
+        lat_long=(1.0, 1.0),
+        journeys=[journey]
+    )
+
+    await Coordinate.create(
+        lat_long=(1.0, 1.1),
+        journeys=[journey]
+    )
+
+
+
     all_coordinates = await Coordinate.all()
+    #breakpoint()
 
     assert len(all_coordinates) == 2
     
 
     all_journeys = await Journey.all()
     assert len(all_journeys) ==1
+
     assert len(all_journeys[0].waypoints) == 2
 
     for coordinate in all_coordinates:
         await coordinate.delete()
 
     all_journeys = await Journey.all()
+    
     assert len(all_journeys[0].waypoints) == 0
 
+    for coordinate in all_coordinates:
+        coordinate.journeys=[]
+   
     all_journeys[0].waypoints=all_coordinates
     await all_journeys[0].save()
 
     all_journeys = await Journey.all()
     assert len(all_journeys[0].waypoints) == 2
 
-    all_journeys[0].waypoints.pop(0)
-    await all_journeys[0].save()
+    waypoint_to_delete = all_journeys[0].waypoints.pop(0)
+    await waypoint_to_delete.delete()
 
     all_journeys = await Journey.all()
     assert len(all_journeys[0].waypoints) == 1
@@ -49,9 +69,17 @@ async def test_database(db_url):
 
     all_journeys = await Journey.all()
     assert len(all_journeys) == 2
-    assert all_journeys[0].waypoints == all_journeys[1].waypoints
+    assert all_journeys[0].waypoints[0].lat_long == all_journeys[1].waypoints[0].lat_long
 
     await all_journeys[1].waypoints[0].delete()
 
     all_journeys = await Journey.all()
     assert all_journeys[0].waypoints == all_journeys[1].waypoints
+
+    assert len(all_journeys[0].waypoints) == 0
+
+    all_journeys[0].waypoints = all_coordinates
+    await all_journeys[0].save()
+
+    all_journeys = await Journey.all()
+    assert len(all_journeys[0].waypoints) == 2

--- a/tests/test_model_connections.py
+++ b/tests/test_model_connections.py
@@ -13,19 +13,15 @@ async def test_model_transactions(loaded_database_and_model):
             await all_employees[-1].delete()
             await all_employees[-2].delete()
 
-            employee = await Employees.create(
-                **all_employees[-1].dict()
-            )
+            employee = await all_employees[-1].insert()
 
             result = await all_employees[-2].save()
 
-    assert  all_employees[-2] == await Employees.get(id=all_employees[-2].id)
+    assert  all_employees[-2] == await Employees.get(employee_id=all_employees[-2].employee_id)
 
     # test unique
     try:
-        await Employees.create(
-            **all_employees[-1].dict()
-        )
+        employee = await all_employees[-1].insert()
     except Exception:
         pass
     else:
@@ -34,15 +30,12 @@ async def test_model_transactions(loaded_database_and_model):
         ), 'expected IntegrityError due to duplicate primary key insert attempts'
 
 
-    data = all_employees[-1].dict()
-    data['id'] = 'special'
-    new_example = Employees(
-        **data
-    )
+    new_employee = all_employees[-1]
+    new_employee.employee_id = 'special'
 
     async with db:
-        await new_example.insert()
+        await new_employee.insert()
 
-        verify_examples = await Employees.filter(id='special')
+        verify_examples = await Employees.filter(employee_id='special')
 
     assert len(verify_examples) == 1

--- a/tests/test_model_deletions.py
+++ b/tests/test_model_deletions.py
@@ -21,14 +21,14 @@ async def test_model_deletions(loaded_database_and_model):
 
     assert len(result) == 200
 
-    employee2 = Employees(**employee.dict())
+    employee2 = employee
 
     try:
         await employee2.insert()
     except Exception as e:
         pass
     
-    employee2.id += '_new'
+    employee2.employee_id += '_new'
     await employee2.insert()
 
     result = await Employees.select('*')

--- a/tests/test_model_insertions.py
+++ b/tests/test_model_insertions.py
@@ -11,23 +11,54 @@ async def test_model_insertions(loaded_database_and_model):
     await all_employees[-2].delete()
     # result = await all_employees[-2].save()
     # deleted_emp = await Employees.get(id=all_employees[-2].id)
-    # breakpoint()
 
+    new_employee = {
+            'employee_id': 'abcd1990', 
+            'employee_info': {
+                'ssn': '199', 
+                'first_name': 'joe', 
+                'last_name': 'last', 
+                'address': '199 lane', 
+                'address2': None, 
+                'city': None, 
+                'zip': None, 
+                'new': None, 
+            }, 
+            'position': [
+                {
+                    'position_id': '1234', 
+                    'name': 'manager', 
+                    'department': {
+                        'department_id': '5678', 
+                        'name': 'hr', 
+                        'company': 'abc company', 
+                        'is_sensitive': False
+                    }
+                }
+            ],
+            'salary': 0.0,
+            'is_employed': True, 
+            'date_employed': None
+        }
     # creation via .create
-    employee = await Employees.create(
-        **all_employees[-1].dict()
-    )
+    employee = await Employees.create(**new_employee)
 
     #breakpoint()
-    # creation via .save
+    # creation via .save #TODO - determine why Save fails to 
+    # update foreign models 
     result = await all_employees[-2].save()
 
-    assert  all_employees[-2] == await Employees.get(id=all_employees[-2].id)
+    
+    verify_emp = await Employees.get(employee_id=all_employees[-2].employee_id)
+
+    assert  all_employees[-2].employee_id == verify_emp.employee_id
+    assert  all_employees[-2].salary == verify_emp.salary
+
 
     # test unique
     try:
         await Employees.create(
-            **all_employees[-1].dict()
+            **new_employee
         )
     except Exception:
         pass
@@ -37,14 +68,14 @@ async def test_model_insertions(loaded_database_and_model):
         ), 'expected IntegrityError due to duplicate primary key insert attempts'
 
 
-    data = all_employees[-1].dict()
-    data['id'] = 'special'
+    data = new_employee
+    data['employee_id'] = 'special'
     new_example = Employees(
         **data
     )
 
     await new_example.insert()
 
-    verify_examples = await Employees.filter(id='special')
+    verify_examples = await Employees.filter(employee_id='special')
 
     assert len(verify_examples) == 1

--- a/tests/test_model_many_to_many.py
+++ b/tests/test_model_many_to_many.py
@@ -1,0 +1,37 @@
+import pytest
+from tests.models import Employee, EmployeeInfo, Positions, Department
+
+@pytest.mark.asyncio
+async def test_model_many_to_many(loaded_database_and_model):
+    db = loaded_database_and_model
+
+    departments = await Department.all()
+    department = departments[0]
+
+    assert len(department.positions) == 1
+    assert len(department.positions[0].employees) == 200
+
+    manager_position = department.positions[0]
+
+    # test removal via pop
+    department.positions.pop(0)
+    await department.save()
+
+    departments = await Department.all()
+    assert len(departments[0].positions) == 0
+
+    manager_position = await Positions.get(Positions.position_id==manager_position.position_id)
+
+    assert len(manager_position.employees) == 200
+    
+    removed_employee = manager_position.employees.pop()
+
+    await manager_position.save()
+
+    manager_position = await Positions.get(Positions.position_id==manager_position.position_id)
+
+    assert len(manager_position.employees) == 199
+    
+    employee = await Employee.get(Employee.employee_id == removed_employee.employee_id)
+    assert len(employee.position) == 0
+

--- a/tests/test_model_many_to_many.py
+++ b/tests/test_model_many_to_many.py
@@ -28,9 +28,10 @@ async def test_model_many_to_many(loaded_database_and_model):
 
     await manager_position.save()
 
-    manager_position = await Positions.get(Positions.position_id==manager_position.position_id)
+    updated_manager_position = await Positions.get(Positions.position_id==manager_position.position_id)
 
-    assert len(manager_position.employees) == 199
+    assert len(updated_manager_position.employees) == 199
+    
     
     employee = await Employee.get(Employee.employee_id == removed_employee.employee_id)
     assert len(employee.position) == 0

--- a/tests/test_model_updates.py
+++ b/tests/test_model_updates.py
@@ -1,3 +1,4 @@
+from builtins import breakpoint
 import pytest
 
 @pytest.mark.asyncio
@@ -11,7 +12,7 @@ async def test_model_updates(loaded_database_and_model):
     employee.employee_info.first_name = 'new name - updated'
     await employee.employee_info.update()
 
-    updated_employee = await Employees.select('*', where={'id': employee.id})
+    updated_employee = await Employees.select('*', where={'employee_id': employee.employee_id})
 
     assert updated_employee[0].employee_info.first_name == 'new name - updated'
 
@@ -29,6 +30,6 @@ async def test_model_updates(loaded_database_and_model):
 
     await updated_employee[0].update()
 
-    modified_employee = await Employees.get(id=updated_employee[0].id)
+    modified_employee = await Employees.get(employee_id=updated_employee[0].employee_id)
 
     assert modified_employee.employee_info.ssn == all_employees[1].employee_info.ssn

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,19 +1,21 @@
 import time
 import pytest
+
 from pydbantic import Database
+from tests.models import Employee
 
 @pytest.mark.asyncio
 async def test_models(database_with_cache):
-    db_path, Employees = database_with_cache
+    db_path, _ = database_with_cache
 
 
-    result = await Employees.select('*')
+    result = await Employee.select('*')
 
     # no data is expected yet
     assert len(result) == 0, 'no data is expected yet'
 
     new_employee = {
-        'id': 'abcd1632173531.8840718', 
+        'employee_id': 'abcd1632173531.8840718', 
         'employee_info': {
             'ssn': '1234', 
             'first_name': 'new name - updated', 
@@ -21,33 +23,33 @@ async def test_models(database_with_cache):
             'address': '123 lane', 
             'address2': None, 'city': None, 'zip': None
         }, 
-        'position': {
-            'id': '1234', 
+        'position': [{
+            'position_id': '1234', 
             'name': 'manager', 
             'department': {
-                'id': '5678', 
-                'name': 'hr', 
+                'department_id': '5678', 
+                'name': 'hr',
                 'company': 'abc company', 
                 'is_sensitive': False
-            }}, 
+            }}], 
         'salary': 0.0, 
         'is_employed': False, 
         'date_employed': None
     }
-
-    employee = Employees(
+    employee = Employee(
         **new_employee
     )
 
     await employee.insert()
 
-    result = await Employees.select('*')
+    result = await Employee.select('*')
 
     assert len(result) == 1, 'expected a single entry'
 
     # verify data in result matches original example
-    assert result[0].id == employee.id
-    assert result[0].employee_info == employee.employee_info
-    assert result[0].position == employee.position
+    assert result[0].employee_id == employee.employee_id
+    assert result[0].employee_info.ssn == employee.employee_info.ssn
+    assert result[0].position[0].position_id == employee.position[0].position_id
+    assert result[0].position[0].name == employee.position[0].name
     assert result[0].salary == employee.salary
     assert result[0].is_employed == employee.is_employed

--- a/tests/test_query_caching.py
+++ b/tests/test_query_caching.py
@@ -30,6 +30,7 @@ async def test_query_caching(loaded_database_and_model_with_cache):
     await employee.update()
 
     verify_employee = await Employee.get(employee_id=employee.employee_id)
+
     assert employee == verify_employee
 
     # should NOT be cached -  yet

--- a/tests/test_query_caching.py
+++ b/tests/test_query_caching.py
@@ -16,7 +16,7 @@ async def test_query_caching(loaded_database_and_model_with_cache):
 
     print(f"perf: {perf} perf2: {perf2}")
     
-    assert len(sel2) == 800
+    assert len(sel2) == 20
 
     # trigger cache clear event
 
@@ -29,7 +29,8 @@ async def test_query_caching(loaded_database_and_model_with_cache):
     employee.salary = 100000.00
     await employee.update()
 
-    assert employee == await Employee.get(id=employee.id)
+    verify_employee = await Employee.get(employee_id=employee.employee_id)
+    assert employee == verify_employee
 
     # should NOT be cached -  yet
     filter_sel = await Employee.filter(salary=0.0)

--- a/tests/test_querying.py
+++ b/tests/test_querying.py
@@ -8,11 +8,11 @@ async def test_querying(loaded_database_and_model_with_cache):
 
     all_employees = await Employee.all()
 
-    assert len(all_employees) == 800
+    assert len(all_employees) == 20
 
-    all_employees[400].salary = 40000
+    all_employees[19].salary = 40000
 
-    await all_employees[400].update()
+    await all_employees[19].update()
 
     # get employee with salary
 
@@ -25,10 +25,10 @@ async def test_querying(loaded_database_and_model_with_cache):
     assert emp_with_salary[0].salary == 40000
 
     manager_position = emp_with_salary[0].position
-
+    #breakpoint()
     # filter on manager positions
     managers = await Employee.filter(
-        position=manager_position, 
+        position=manager_position[0],
         salary=40000, 
         employee_info=emp_with_salary[0].employee_info
     )
@@ -37,7 +37,7 @@ async def test_querying(loaded_database_and_model_with_cache):
 
     # filter on manager positions
     managers = await Employee.filter(
-        Employee.position==manager_position, 
+        Employee.position==manager_position[0], 
         Employee.salary==40000, 
         Employee.employee_info==emp_with_salary[0].employee_info
     )
@@ -47,13 +47,13 @@ async def test_querying(loaded_database_and_model_with_cache):
 
     assert managers[0].employee_info.ssn == emp_with_salary[0].employee_info.ssn
 
-    manager = await Employee.get(id=managers[0].id)
+    manager = await Employee.get(employee_id=managers[0].employee_id)
 
-    assert manager.id == managers[0].id
+    assert manager.employee_id == managers[0].employee_id
 
-    manager = await Employee.get(Employee.id==managers[0].id)
+    manager = await Employee.get(Employee.employee_id==managers[0].employee_id)
 
-    assert manager.id == managers[0].id
+    assert manager.employee_id == managers[0].employee_id
 
     ranged_salary = await Employee.filter(
         Employee.salary.matches([40000, 10000, 30000])


### PR DESCRIPTION
## Description
This PR implements Dynamic model relationships, which improves the current `DataBaseModel` relationship & model references by implementing dynamic creation of link tables used to associate one-to-one, many-to-one, and many-to-many relationships. By implementing link-tables, nested models can be queried much more efficiently,  related models dynamically receive updates on changes / deletions. Link tables also provide the ability for backward references or bidirectional (circular) between models. 

### Example Models
```python
from uuid import uuid4
from datetime import datetime
from typing import List, Optional, Union
from pydbantic import DataBaseModel, PrimaryKey

class Department(DataBaseModel):
    department_id: str = PrimaryKey()
    name: str
    company: str
    is_sensitive: bool = False
    positions: List[Optional['Positions']] = []  # # Forward Reference to Positions

class Positions(DataBaseModel):
    position_id: str = PrimaryKey()
    name: str
    department: Department = None
    employees: List[Optional['Employee']] = []  # Forward Reference to Employee

class EmployeeInfo(DataBaseModel):
    ssn: str = PrimaryKey()
    first_name: str
    last_name: str
    address: str
    address2: Optional[str]
    city: Optional[str]
    zip: Optional[int]
    new: Optional[str]
    employee: Optional[Union['Employee', dict]] = None # Forward Reference to Employee

class Employee(DataBaseModel):
    employee_id: str = PrimaryKey()
    employee_info: Optional[EmployeeInfo] = None
    position: List[Optional[Positions]] = []   
    salary: float
    is_employed: bool
    date_employed: Optional[str]

```
Relationships & link tables are dynamically created when added to a Database. Forward / Circular references provide their associated `DataBaseModel` with the same access to their related `DataBaseModel` reference(s). Many to many relationships should have a default value of [], while Many to One or One to One should have a default value of None, allowing validation when related models are deleted. 

### What Else has changed
- #24 - Added default `arbitrary_types_allowed=True` for `DataBaseModel` allowing custom non-BaseModel type classes to be used as fields.
```python
    class Config:
       arbitrary_types_allowed = True
```
- Upgraded SQLAlchemy from 1.3.24->1.4.28 and databases==0.5.3
- Improved Logging of cache invalidation, invalidation moved to debug
- Migrations improved to include models with relationships (including link tables).  
