### PR TITLE
Replace aioredis with redis' built-in asyncio support

### DIFF
--- a/pydbantic/cache.py
+++ b/pydbantic/cache.py
@@ -4,7 +4,7 @@ from collections import deque
 from pickle import dumps, loads
 import asyncio
 
-import aioredis
+from redis import asyncio as aioredis
 
 
 class Redis:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 SQLAlchemy==1.4.28
 databases==0.6.0
-aioredis==2.0.0 
+redis>=4.2.0
 pydantic>=1.9.1
 asyncpg==0.24.0
 aiosqlite==0.17.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import setuptools
 BASE_REQUIREMENTS = [
     'SQLAlchemy==1.4.28',
     'databases==0.5.3', 
-    'aioredis==2.0.0', 
+    'redis>=4.2.0', 
     'pydantic>=1.9.1',
     'alembic==1.8.1'
 ]


### PR DESCRIPTION
aioredis has been deprecated, and asyncio support has been merged into the redis library itself.

aioredis has open issues preventing it to work with Python 3.11, so this change is also functionally necessary by now.