### PR TITLE
Fix database connction pool reference handling

### DIFF
--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -13,6 +13,7 @@ from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from databases import Database as _Database
 from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from pydbantic.cache import Redis
 from pydbantic.core import BaseMeta, DatabaseInit, DataBaseModel, TableMeta

--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -36,6 +36,7 @@ class Database:
         debug: bool = False,
         testing: bool = False,
         use_alembic: bool = False,
+        echo: bool = False,
     ):
         self.connection_map = {}
         self.DB_URL = db_url
@@ -54,6 +55,7 @@ class Database:
             connect_args={"check_same_thread": False}
             if "sqlite" in str(self.DB_URL)
             else {},
+            echo=echo,
         )
         self.use_alembic = use_alembic
         self.__metadata__: BaseMeta = BaseMeta()
@@ -656,6 +658,7 @@ class Database:
         debug: bool = False,
         testing: bool = False,
         use_alembic: bool = False,
+        echo: bool = False,
     ):
 
         cache_config = {"cache_enabled": cache_enabled}
@@ -669,6 +672,7 @@ class Database:
             debug=debug,
             testing=testing,
             use_alembic=use_alembic,
+            echo=echo,
             **cache_config,
         )
 

--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -13,7 +13,6 @@ from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from databases import Database as _Database
 from sqlalchemy import create_engine
-from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 
 from pydbantic.cache import Redis
 from pydbantic.core import BaseMeta, DatabaseInit, DataBaseModel, TableMeta

--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -701,8 +701,9 @@ class Database:
         )
         database = _Database(self.DB_URL, **conn_factory)
         await database.connect()
+        self._database = database
         while True:
-            status = yield database
+            status = yield "running"
             if status == "finished":
                 self.log.debug(f"db_connection - closed")
                 break
@@ -710,7 +711,9 @@ class Database:
         yield database.disconnect()
 
     async def __aenter__(self):
-        return await self._connection.asend(None)
+        if not self._connection.ag_running:
+            await self._connection.asend(None)
+        return self._database
 
     async def __aexit__(self, exc_type, exc, tb):
         pass

--- a/pydbantic/database.py
+++ b/pydbantic/database.py
@@ -36,8 +36,8 @@ class Database:
         debug: bool = False,
         testing: bool = False,
         use_alembic: bool = False,
-        echo: bool = False,
     ):
+        self.connection_map = {}
         self.DB_URL = db_url
         self.tables = []
         self.cache_enabled = cache_enabled
@@ -54,12 +54,9 @@ class Database:
             connect_args={"check_same_thread": False}
             if "sqlite" in str(self.DB_URL)
             else {},
-            echo=echo,
         )
-
         self.use_alembic = use_alembic
         self.__metadata__: BaseMeta = BaseMeta()
-        self._connection = self.db_connection()
 
         self.DEFAULT_TRANSLATIONS = DEFAULT_TRANSLATIONS
 
@@ -613,8 +610,8 @@ class Database:
 
         self.log.debug(f"database query: {query} - values {values}")
 
-        async with self as database:
-            async with database.connection() as conn:
+        async with self as conn:
+            async with conn.connection():
                 return await conn.execute(query=query, values=values)
 
     async def execute_many(self, query, values):
@@ -622,9 +619,8 @@ class Database:
         if self.cache_enabled:
             await self.cache.invalidate(query.table.name)
 
-        async with self as database:
-            async with database.connection() as conn:
-                print(f"running {query} insertion of {len(values)} values")
+        async with self as conn:
+            async with conn.connection():
                 return await conn.execute_many(query=query, values=values)
 
     async def fetch(self, query, table_name, values=None):
@@ -640,8 +636,8 @@ class Database:
 
         self.log.debug(f"running query: {query} with {values}")
 
-        async with self as database:
-            async with database.connection() as conn:
+        async with self as conn:
+            async with conn.connection():
                 row = await conn.fetch_all(query=query)
 
         if self.cache_enabled and row:
@@ -693,27 +689,33 @@ class Database:
         return self
 
     async def db_connection(self):
-        pool_config = {"min_size": 5, "max_size": 20}
+        pool_config = {"min_size": 3, "max_size": 5}
         conn_factory = (
             {"factory": SQLiteConnection}
             if "sqlite" in self.DB_URL.lower()
             else pool_config
         )
-        database = _Database(self.DB_URL, **conn_factory)
-        await database.connect()
-        self._database = database
-        while True:
-            status = yield "running"
-            if status == "finished":
-                self.log.debug(f"db_connection - closed")
-                break
 
-        yield database.disconnect()
+        async with _Database(self.DB_URL, **conn_factory) as connection:
+            while True:
+                status = yield connection
+                if status == "finished":
+                    self.log.debug(f"db_connection - closed")
+                    break
+
+    async def add_db_pool(self):
+        conn_id = str(uuid.uuid4())
+        db_connection = self.db_connection()
+        self.connection_map[conn_id] = db_connection
+        return await db_connection.asend(None)
 
     async def __aenter__(self):
-        if not self._connection.ag_running:
-            await self._connection.asend(None)
-        return self._database
+        for conn_id in self.connection_map:
+            if self.connection_map[conn_id].ag_running:
+                continue
+            return await self.connection_map[conn_id].asend(None)
+
+        return await self.add_db_pool()
 
     async def __aexit__(self, exc_type, exc, tb):
         pass


### PR DESCRIPTION
everted to connection_map usage, removing connection map timeout as race conditions can cause unexpected connection termination. connection_map remains vital for allowing connections within async tasks. Tasks are not able to share connection pools, and thus need the ability to generate their own pool for use

* adding optional echo argument to allow easier printing of sql commands issued by pydbanitc