### PR TITLE
Implemented delete_filter, allowing conditions / column filters to delete 

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,13 +172,22 @@ See also filtering [operators](https://pydbantic.readthedocs.io/en/latest/model-
 
 ### Deleting
 ```python
-    # remove all managers not employed anymore
+    # one by one
     for manager in await Employee.filter(
         position=hr_manager,
         is_employed=False
     ):
         await manager.delete()
 ```
+
+```python
+    # all at once
+    await Employee.delete_filter(
+        Employee.is_employed == True
+    )
+
+```
+
 ### Updating
 ```python
     # raise salary of all managers

--- a/docs/model-usage.md
+++ b/docs/model-usage.md
@@ -280,6 +280,11 @@ terminated_employees = await Employees.filter(
 await Employees.delete_many(terminated_employees)
 ```
 
+```python
+await Employees.delete_filter(
+    Employees.contains('name', 'terminated')
+)
+```
 
 ### Models with arrays of Foreign Objects
 

--- a/pydbantic/core.py
+++ b/pydbantic/core.py
@@ -1271,7 +1271,6 @@ class DataBaseModel(BaseModel):
         session_query: Query,
         tables_to_select: list,
         models_selected: set,
-        delete_query: bool = False,
         root_model: T = None,
     ) -> Tuple[Query, List[Tuple[sqlalchemy.Table, T, str, T]]]:
         """
@@ -1304,7 +1303,7 @@ class DataBaseModel(BaseModel):
 
         session_query = _link_table.outer_join(session_query)
 
-        if not cls is root_model and not delete_query:
+        if not cls is root_model:
             session_query = session_query.add_columns(*[c for c in table.c])
             tables_to_select.append((table, cls, column_ref, model_ref))
         models_selected.add(cls.__tablename__)
@@ -1312,12 +1311,7 @@ class DataBaseModel(BaseModel):
 
         for foreign_model, column_ref in foreign_models:
             session_query, tables_to_select = foreign_model.deep_join(
-                cls,
-                column_ref,
-                session_query,
-                tables_to_select,
-                models_selected,
-                delete_query=delete_query,
+                cls, column_ref, session_query, tables_to_select, models_selected
             )
         return session_query, tables_to_select
 

--- a/tests/test_model_deletions.py
+++ b/tests/test_model_deletions.py
@@ -1,5 +1,7 @@
 import pytest
 
+from tests.models import Department
+
 
 @pytest.mark.asyncio
 async def test_model_deletions(loaded_database_and_model):
@@ -36,8 +38,12 @@ async def test_model_deletions(loaded_database_and_model):
 
     assert len(result) == 201
 
-    await Employees.delete_many(result)
+    await Employees.delete_many(result[:100])
 
     result = await Employees.all()
 
-    assert len(result) == 0
+    assert len(result) == 101
+
+    assert await Employees.delete_filter(Employees.is_employed == True) == 101
+
+    result = await Employees.count() == 0

--- a/tests/test_model_deletions.py
+++ b/tests/test_model_deletions.py
@@ -44,6 +44,6 @@ async def test_model_deletions(loaded_database_and_model):
 
     assert len(result) == 101
 
-    assert await Employees.delete_filter(Employees.is_employed == True) == 101
+    await Employees.delete_filter(Employees.is_employed == True)
 
-    result = await Employees.count() == 0
+    assert await Employees.count() == 0


### PR DESCRIPTION
## Description
This PR implements delete functionality that can delete corresponding model rows matching an input filter:
```python
    await Employee.delete_filter(
        Employee.is_employed == True
    )

```

```python
await Employees.delete_filter(
    Employees.contains('name', 'terminated')
)
```